### PR TITLE
docs: improve README quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,54 @@
 # Terraform Provider for OpenAI
 
-Terraform provider for OpenAI administration APIs.
+The OpenAI Terraform provider gives Terraform configurations convenient access
+to the [OpenAI Administration API](https://developers.openai.com/api/reference/administration/overview).
+Use it to manage organization-level resources such as projects, users, groups,
+roles, service accounts, certificates, rate limits, spend alerts, and related
+project settings.
 
-This provider was generated from OpenAPI and provider config inputs.
+See [`docs/`](docs/index.md) for resource and data source documentation.
 
-See `docs/index.md` for authentication, environment variable, and provider configuration details.
+## Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/downloads) CLI 1.0 or later
+- An [OpenAI Admin API key](https://platform.openai.com/settings/organization/admin-keys)
+
+Admin API keys are required for Administration API endpoints and cannot be used
+for non-administration OpenAI API endpoints.
+
+## Usage
+
+Set your Admin API key in the environment:
+
+```sh
+export OPENAI_ADMIN_KEY="<your-admin-api-key>"
+```
+
+Then create a Terraform configuration:
+
+```terraform
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    openai = {
+      source = "openai/openai"
+    }
+  }
+}
+
+provider "openai" {
+  # The provider reads OPENAI_ADMIN_KEY by default.
+  # You can also set admin_api_key, organization, and project here.
+}
+
+resource "openai_project" "example" {
+  name = "terraform-managed"
+}
+```
+
+See [`docs/index.md`](docs/index.md) for provider configuration details and the
+full resource and data source documentation.
 
 ## License
 


### PR DESCRIPTION
## Description

Improves the top-level README with a clearer overview of the Terraform provider and its relationship to the OpenAI Administration API.

This adds:

- a high-level description of the provider's Administration API coverage
- a Requirements section with Terraform CLI 1.0+ and Admin API key requirements
- a Usage section with a minimal provider configuration and `openai_project` example
- links to the Administration API overview and provider documentation

This is documentation-only and does not change provider behavior.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Validation

Not run; documentation-only change.