### PR TITLE
fix: link Admin API docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ See [`docs/`](docs/index.md) for resource and data source documentation.
 - [Terraform](https://developer.hashicorp.com/terraform/downloads) CLI 1.0 or later
 - An [OpenAI Admin API key](https://platform.openai.com/settings/organization/admin-keys)
 
-Admin API keys are required for Administration API endpoints and cannot be used
-for non-administration OpenAI API endpoints.
+[Admin API keys](https://developers.openai.com/api/docs/guides/admin-apis) are
+required for Administration API endpoints and cannot be used for
+non-administration OpenAI API endpoints.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- Link the Requirements section's Admin API key description to the OpenAI Admin API documentation.

## Why

The README explained that Admin API keys are limited to administration endpoints but did not link that explanation to the corresponding OpenAI docs. This gives users a direct path to the authoritative guidance without changing provider behavior.

## Validation

- `git diff --check`