### PR TITLE
Add advanced CodeQL workflow for complete Go coverage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,68 @@
+name: CodeQL
+
+# GitHub's default CodeQL setup must be disabled before this advanced workflow
+# can upload results.
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "17 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  packages: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: go
+            build-mode: manual
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: |
+            go.sum
+            tools/go.sum
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      # Default Go autobuild invokes the repository's broad `make` target,
+      # which requires golangci-lint and then falls back to extracting only
+      # non-test packages. Compile every test package without running tests so
+      # CodeQL can analyze the test sources as well as the production sources.
+      # tools/tools.go remains intentionally excluded by its `generate` build tag.
+      - name: Compile Go packages for CodeQL
+        if: matrix.language == 'go'
+        run: go test -run '^$' ./...
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,11 +24,11 @@ jobs:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
 
-    # These settings are ignored by the Actions extractor. Go build tracing
-    # must be selected before CodeQL initializes its database, and test files
-    # are excluded unless the extractor is explicitly told to include them.
+    # These settings are ignored by the Actions extractor. Supplying an
+    # explicit dependency command keeps Go's autobuilder from invoking the
+    # repository's broad `make` target, and test files are otherwise excluded.
     env:
-      CODEQL_EXTRACTOR_GO_BUILD_TRACING: "on"
+      CODEQL_EXTRACTOR_GO_BUILD_COMMAND: "go mod download"
       CODEQL_EXTRACTOR_GO_OPTION_EXTRACT_TESTS: "true"
 
     strategy:
@@ -38,7 +38,7 @@ jobs:
           - language: actions
             build-mode: none
           - language: go
-            build-mode: manual
+            build-mode: autobuild
 
     steps:
       - name: Checkout repository
@@ -59,18 +59,6 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-
-      # Default Go autobuild invokes the repository's broad `make` target,
-      # which requires golangci-lint and then falls back to extracting only
-      # non-test packages. Compile every test package without running tests so
-      # CodeQL can analyze the test sources as well as the production sources.
-      # tools/tools.go remains intentionally excluded by its `generate` build tag.
-      - name: Compile Go packages for CodeQL
-        if: matrix.language == 'go'
-        env:
-          # Do not let restored Go build artifacts hide compiler invocations.
-          GOCACHE: ${{ runner.temp }}/codeql-go-build-cache
-        run: go test -run '^$' ./...
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,13 @@ jobs:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
 
+    # These settings are ignored by the Actions extractor. Go build tracing
+    # must be selected before CodeQL initializes its database, and test files
+    # are excluded unless the extractor is explicitly told to include them.
+    env:
+      CODEQL_EXTRACTOR_GO_BUILD_TRACING: "on"
+      CODEQL_EXTRACTOR_GO_OPTION_EXTRACT_TESTS: "true"
+
     strategy:
       fail-fast: false
       matrix:
@@ -61,9 +68,6 @@ jobs:
       - name: Compile Go packages for CodeQL
         if: matrix.language == 'go'
         env:
-          # Manual Go builds require tracing to be explicitly enabled so the
-          # extractor observes compiler invocations made by `go test`.
-          CODEQL_EXTRACTOR_GO_BUILD_TRACING: "on"
           # Do not let restored Go build artifacts hide compiler invocations.
           GOCACHE: ${{ runner.temp }}/codeql-go-build-cache
         run: go test -run '^$' ./...

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,6 +60,12 @@ jobs:
       # tools/tools.go remains intentionally excluded by its `generate` build tag.
       - name: Compile Go packages for CodeQL
         if: matrix.language == 'go'
+        env:
+          # Manual Go builds require tracing to be explicitly enabled so the
+          # extractor observes compiler invocations made by `go test`.
+          CODEQL_EXTRACTOR_GO_BUILD_TRACING: "on"
+          # Do not let restored Go build artifacts hide compiler invocations.
+          GOCACHE: ${{ runner.temp }}/codeql-go-build-cache
         run: go test -run '^$' ./...
 
       - name: Perform CodeQL analysis


### PR DESCRIPTION
## Summary

- add an advanced CodeQL workflow for Go and GitHub Actions
- use CodeQL's native Go autobuilder with `go mod download` as the explicit dependency command, avoiding the repository's broad `make` target
- enable CodeQL's Go test-file extractor option so `*_test.go` files are analyzed
- pin workflow actions to immutable commit SHAs and preserve weekly, push, pull request, and manual scans

## Why

The current default Go setup probes the repository's default `make` target while preparing dependencies. That target reaches `golangci-lint`, which is not installed in the CodeQL environment, so GitHub reports a build error before continuing with native extraction. Native Go extraction excludes test files by default, which is why the existing scan covers only 65 of 123 Go files.

This workflow sets `CODEQL_EXTRACTOR_GO_BUILD_COMMAND=go mod download`, giving the autobuilder the dependency command it actually needs instead of letting it probe `make`. It also sets `CODEQL_EXTRACTOR_GO_OPTION_EXTRACT_TESTS=true`, which includes the test sources without executing tests or acceptance-test side effects.

The verified PR run extracted both Go modules, finalized the database, ran the query suite, and produced SARIF. It reported exactly one unprocessed Go file, matching the intentionally generation-only `tools/tools.go` file.

## Validation

- `actionlint` v1.7.12
- YAML parsing with `yq`
- `go mod download`
- [CodeQL workflow run 29609222963](https://github.com/openai/terraform-provider-openai/actions/runs/29609222963): Go extraction and query analysis completed; both language jobs failed only when GitHub rejected advanced-setup SARIF while default setup remains enabled

## Rollout

Keep this PR in draft while default setup remains enabled. GitHub rejects uploads from advanced CodeQL workflows while default setup is active, so the current red CodeQL checks are expected configuration conflicts.

When ready to merge:

1. Disable the repository's default CodeQL setup under **Settings → Advanced Security → CodeQL analysis**.
2. Re-run this PR's failed CodeQL jobs and verify both Go and GitHub Actions analyses pass.
3. Mark the PR ready and merge it promptly.
4. Run the CodeQL workflow manually on `main` once to confirm the steady-state configuration.

Coordinating the settings change with the rerun and merge avoids maintaining two competing CodeQL configurations and minimizes any coverage gap.