### PR TITLE
ci: prepare required checks for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   pull_request:
+  merge_group:
+    types:
+      - checks_requested
   push:
     branches:
       - main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
+    name: CodeQL (${{ matrix.language }})
     runs-on: ubuntu-latest
 
     # These settings are ignored by the Actions extractor. Supplying an

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types:
+      - checks_requested
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

- run all six required CI checks for GitHub merge-group commits
- run both advanced CodeQL analyses for queued merge commits
- give the queued analyses stable, unique status contexts: `CodeQL (actions)` and `CodeQL (go)`

## Why

GitHub Actions required checks must subscribe to the separate `merge_group: checks_requested` event before merge queue can be enabled. GitHub's code-scanning merge protection does not apply to merge groups, so the advanced CodeQL jobs also need unique status contexts that can be required explicitly by the queue ruleset.

## Impact

Once the merge queue is enabled, `Format`, `Build`, `Test`, `Lint`, `Terraform Format`, `Generated Docs`, `CodeQL (actions)`, and `CodeQL (go)` will run against—and block—each prospective queued merge commit. Existing pull-request, main-branch push, schedule, manual-dispatch, duplicate compatibility-test, Release Please, and tag-release behavior remains unchanged.

The ordinary push trigger is scoped only to `main`, so no `gh-readonly-queue/**` exclusion is needed. CodeQL's default SARIF uploads remain enabled; requiring both CodeQL contexts makes the queue wait for upload completion before the temporary queue ref can be deleted.

## Validation

- workflow YAML parsed successfully
- focused `merge_group: checks_requested` trigger and unique-check assertions
- `go build ./...`
- `go test ./...`
- `gofmt -s -l -e .`
- `terraform fmt -check -recursive examples`
- `git diff --check`
- thermo-nuclear code-quality review (no findings)

## Follow-up

After this PR lands, atomically update the existing `main` ruleset to add `CodeQL (actions)` and `CodeQL (go)` as required status checks and enable the squash-based merge queue, while preserving every existing protection, required check, code-quality/code-scanning rule, and bypass actor. Then independently read back the stored ruleset, effective branch rules, and live queue configuration.