### PR TITLE
ci: use GitHub App for Release Please

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This file is used to automatically assign reviewers to PRs
+# For more information see: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+** @openai/sdks-team

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,7 @@ permissions: {}
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    environment: release-please
+    environment: release
     steps:
       - name: Create release app token
         id: app-token

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,16 +5,25 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    environment: release-please
     steps:
+      - name: Create release app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.OPENAI_SDKS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.OPENAI_SDKS_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           skip-labeling: true


### PR DESCRIPTION
## Summary

- mint a repository-scoped installation token for the `openai-sdks` GitHub App from environment configuration
- pass that token to Release Please and disable the workflow's built-in `GITHUB_TOKEN` permissions
- limit the installation token to the contents and pull-request permissions this repository needs
- require SDK-team code-owner review for repository changes

## Why

Release Please currently authenticates with `GITHUB_TOKEN`. Events created with that token do not normally start downstream workflows, so the generated release PR does not receive the repository's normal CI checks. A GitHub App installation token causes the release branch push and pull-request events to trigger Actions normally.

## Repository configuration

- [x] confirm the `openai-sdks` GitHub App installation includes this repository with contents and pull-request write permissions
- [x] create an unreviewed `release` environment restricted to `main`
- [x] add environment secret `OPENAI_SDKS_APP_PRIVATE_KEY`
- [x] add environment variable `OPENAI_SDKS_APP_CLIENT_ID` with the verified App client ID
- [x] require code-owner review in the active `main` ruleset

The `release` environment, App installation, branch policy, variable, and secret metadata were verified on August 4, 2026. The existing `publish` environment is intentionally not reused: it protects the provider's signing credentials with a required-reviewer gate, which would pause every Release Please run.

## Validation

- thermo-nuclear code quality review
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release-please.yml`
- YAML parse with Ruby/Psych
- `make build test`
- `test -z "$(gofmt -s -l -e .)"`
- `terraform fmt -check -recursive examples`
- `git diff --check`

## Rollback Plan

- [x] Revert this change to restore Release Please's use of `GITHUB_TOKEN`.

## Changes to Security Controls

Release Please moves from the workflow-scoped `GITHUB_TOKEN` to a repository-scoped GitHub App installation token. The workflow's default token receives no permissions; the installation token is constrained to contents and pull-request writes and is sourced from the dedicated `release` environment. Repository-wide ownership is assigned to `@openai/sdks-team`, and the active `main` ruleset requires code-owner approval.
