### PR TITLE
build: publish provider SBOMs

### DIFF
--- a/.github/actions/verify-release-sboms/action.yml
+++ b/.github/actions/verify-release-sboms/action.yml
@@ -1,0 +1,41 @@
+name: Verify release SBOMs
+description: Build a release snapshot and verify every archive has a valid, checksummed SBOM.
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      with:
+        go-version-file: go.mod
+        cache: true
+
+    - name: Install Syft
+      uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      with:
+        syft-version: v1.51.0
+
+    - name: Build release snapshot and SBOMs
+      uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+      with:
+        distribution: goreleaser
+        version: v2.16.0
+        args: release --snapshot --clean --skip=sign
+
+    - name: Verify release SBOMs
+      shell: bash
+      run: |
+        archive_count="$(find dist -type f -name '*.zip' | wc -l | tr -d ' ')"
+        sbom_count="$(find dist -type f -name '*.spdx.json' | wc -l | tr -d ' ')"
+        checksum_file="$(find dist -type f -name '*_SHA256SUMS' -print -quit)"
+
+        test "$archive_count" -gt 0
+        test "$sbom_count" -eq "$archive_count"
+        test -n "$checksum_file"
+
+        while IFS= read -r -d '' archive; do
+          sbom="${archive}.spdx.json"
+          test -f "$sbom"
+          jq -e '.spdxVersion and (.packages | length > 0)' "$sbom" >/dev/null
+          grep -Fq "  $(basename "$sbom")" "$checksum_file"
+        done < <(find dist -type f -name '*.zip' -print0)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,36 +153,5 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Install Syft
-        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-        with:
-          syft-version: v1.51.0
-
-      - name: Build release snapshot and SBOMs
-        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
-        with:
-          distribution: goreleaser
-          version: v2.16.0
-          args: release --snapshot --clean --skip=sign
-
       - name: Verify release SBOMs
-        shell: bash
-        run: |
-          archive_count="$(find dist -type f -name '*.zip' | wc -l | tr -d ' ')"
-          sbom_count="$(find dist -type f -name '*.spdx.json' | wc -l | tr -d ' ')"
-          checksum_file="$(find dist -type f -name '*_SHA256SUMS' -print -quit)"
-
-          test "$archive_count" -gt 0
-          test "$sbom_count" -eq "$archive_count"
-          test -n "$checksum_file"
-
-          while IFS= read -r -d '' sbom; do
-            jq -e '.spdxVersion and (.packages | length > 0)' "$sbom" >/dev/null
-            grep -Fq "  $(basename "$sbom")" "$checksum_file"
-          done < <(find dist -type f -name '*.spdx.json' -print0)
+        uses: ./.github/actions/verify-release-sboms

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,3 +142,47 @@ jobs:
         run: |
           make generate
           git diff --exit-code -- docs examples
+
+  release-sbom:
+    name: Release SBOM
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          syft-version: v1.51.0
+
+      - name: Build release snapshot and SBOMs
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          distribution: goreleaser
+          version: v2.16.0
+          args: release --snapshot --clean --skip=sign
+
+      - name: Verify release SBOMs
+        shell: bash
+        run: |
+          archive_count="$(find dist -type f -name '*.zip' | wc -l | tr -d ' ')"
+          sbom_count="$(find dist -type f -name '*.spdx.json' | wc -l | tr -d ' ')"
+          checksum_file="$(find dist -type f -name '*_SHA256SUMS' -print -quit)"
+
+          test "$archive_count" -gt 0
+          test "$sbom_count" -eq "$archive_count"
+          test -n "$checksum_file"
+
+          while IFS= read -r -d '' sbom; do
+            jq -e '.spdxVersion and (.packages | length > 0)' "$sbom" >/dev/null
+            grep -Fq "  $(basename "$sbom")" "$checksum_file"
+          done < <(find dist -type f -name '*.spdx.json' -print0)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,22 @@ permissions:
   contents: write
 
 jobs:
+  release-sbom:
+    name: Release SBOM
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Verify release SBOMs
+        uses: ./.github/actions/verify-release-sboms
+
   goreleaser:
+    needs: release-sbom
     runs-on: ubuntu-latest
     environment: publish
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          syft-version: v1.51.0
+
       - name: Check publish environment secrets
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,6 +36,11 @@ archives:
 - formats:
   - zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+sboms:
+- id: provider-archives
+  artifacts: archive
+  documents:
+    - '${artifact}.spdx.json'
 checksum:
   extra_files:
     - glob: 'terraform-registry-manifest.json'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -49,7 +49,7 @@ To publish a provider version:
 
 The `Release` workflow waits for the `publish` environment checks, imports the GPG key from environment secrets, and runs GoReleaser. GoReleaser builds OS/architecture zip files, generates an SPDX JSON software bill of materials (SBOM) for each zip, includes the SBOMs in the signed checksum file, includes `terraform-registry-manifest.json`, and creates the GitHub Release.
 
-CI builds a snapshot release and verifies that every provider zip has a non-empty SBOM listed in the checksum file. A release must not be published if the `Release SBOM` check fails.
+CI builds a snapshot release and verifies that every provider zip has a non-empty SBOM listed in the checksum file. The tag-triggered `Release` workflow runs the same `Release SBOM` verification before its publish job, so a release cannot be published if that check fails.
 
 Once the public Terraform Registry is connected to the public repository, finalized GitHub Releases are ingested by the Registry.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -47,7 +47,9 @@ To publish a provider version:
    git push origin v0.1.0
    ```
 
-The `Release` workflow waits for the `publish` environment checks, imports the GPG key from environment secrets, and runs GoReleaser. GoReleaser builds OS/architecture zip files, generates checksums, signs the checksum file, includes `terraform-registry-manifest.json`, and creates the GitHub Release.
+The `Release` workflow waits for the `publish` environment checks, imports the GPG key from environment secrets, and runs GoReleaser. GoReleaser builds OS/architecture zip files, generates an SPDX JSON software bill of materials (SBOM) for each zip, includes the SBOMs in the signed checksum file, includes `terraform-registry-manifest.json`, and creates the GitHub Release.
+
+CI builds a snapshot release and verifies that every provider zip has a non-empty SBOM listed in the checksum file. A release must not be published if the `Release SBOM` check fails.
 
 Once the public Terraform Registry is connected to the public repository, finalized GitHub Releases are ingested by the Registry.
 


### PR DESCRIPTION
## Summary

- generate an SPDX JSON SBOM for every provider release archive with Syft
- include SBOMs in the signed GoReleaser checksum manifest
- add a CI snapshot build that verifies archive/SBOM parity, non-empty SPDX package data, and checksum coverage
- document the release and maintenance expectations

This is the repository-side SBOM work for HashiCorp Terraform Partner Premier qualification.

## Validation

- `make build`
- `make test`
- `make lint`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `goreleaser check`
- local GoReleaser snapshot: 13 archives, 13 SPDX JSON SBOMs, all non-empty and listed in the checksum manifest

Acceptance tests were not run because this environment does not have `TF_ACC`, `OPENAI_ADMIN_KEY`, or the required Admin API fixtures.