### PR TITLE
fix: verify release artifact integrity before signing

### DIFF
--- a/.github/actions/verify-release-sboms/action.yml
+++ b/.github/actions/verify-release-sboms/action.yml
@@ -36,18 +36,4 @@ runs:
 
     - name: Verify release SBOMs
       shell: bash
-      run: |
-        archive_count="$(find dist -type f -name '*.zip' | wc -l | tr -d ' ')"
-        sbom_count="$(find dist -type f -name '*.spdx.json' | wc -l | tr -d ' ')"
-        checksum_file="$(find dist -type f -name '*_SHA256SUMS' -print -quit)"
-
-        test "$archive_count" -gt 0
-        test "$sbom_count" -eq "$archive_count"
-        test -n "$checksum_file"
-
-        while IFS= read -r -d '' archive; do
-          sbom="${archive}.spdx.json"
-          test -f "$sbom"
-          jq -e '.spdxVersion and (.packages | length > 0)' "$sbom" >/dev/null
-          grep -Fq "  $(basename "$sbom")" "$checksum_file"
-        done < <(find dist -type f -name '*.zip' -print0)
+      run: go run "$GITHUB_ACTION_PATH/verify.go" dist/*_SHA256SUMS

--- a/.github/actions/verify-release-sboms/fixture_archive_test.go
+++ b/.github/actions/verify-release-sboms/fixture_archive_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"debug/elf"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeReleaseFixtureArchive(t *testing.T, path string) {
+	t.Helper()
+
+	var archive bytes.Buffer
+	writer := zip.NewWriter(&archive)
+	provider, err := writer.Create("terraform-provider-openai_v1.2.3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := provider.Write(releaseFixtureExecutable(t)); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	writeFixtureFile(t, path, archive.Bytes())
+
+	name := filepath.Base(path)
+	document := map[string]any{
+		"spdxVersion": "SPDX-2.3",
+		"name":        name,
+		"relationships": []map[string]string{{
+			"spdxElementId": "SPDXRef-DOCUMENT", "relationshipType": "DESCRIBES",
+			"relatedSpdxElement": "SPDXRef-provider",
+		}},
+		"packages": []map[string]string{
+			{"SPDXID": "SPDXRef-provider", "name": name,
+				"versionInfo": "sha256:" + fmt.Sprintf("%x", sha256.Sum256(archive.Bytes())),
+				"supplier":    "NOASSERTION"},
+			{"name": "github.com/openai/openai-go/v3", "versionInfo": "v3.51.0", "licenseConcluded": "Apache-2.0"},
+			{"name": "github.com/hashicorp/go-plugin", "versionInfo": "v1.7.0"},
+		},
+	}
+	encoded, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFixtureFile(t, path+".spdx.json", encoded)
+}
+
+func releaseFixtureExecutable(t *testing.T) []byte {
+	t.Helper()
+
+	modules := "path\tgithub.com/openai/terraform-provider-openai\n" +
+		"mod\tgithub.com/openai/terraform-provider-openai\t(devel)\t\n" +
+		"dep\tgithub.com/openai/openai-go/v3\tv3.51.0\th1:fixture\n" +
+		"dep\tgithub.com/hashicorp/go-plugin\tv1.7.0\th1:fixture\n"
+	modules = strings.Repeat("x", 16) + modules + strings.Repeat("x", 16)
+	info := make([]byte, 32)
+	copy(info, []byte("\xff Go buildinf:"))
+	info[14], info[15] = 8, 2
+	info = binary.AppendUvarint(info, uint64(len("go1.25.8")))
+	info = append(info, "go1.25.8"...)
+	info = binary.AppendUvarint(info, uint64(len(modules)))
+	info = append(info, modules...)
+
+	header := elf.Header64{
+		Type: uint16(elf.ET_EXEC), Machine: uint16(elf.EM_X86_64),
+		Version: uint32(elf.EV_CURRENT), Phoff: 64, Ehsize: 64, Phentsize: 56, Phnum: 1,
+	}
+	copy(header.Ident[:], []byte{0x7f, 'E', 'L', 'F',
+		byte(elf.ELFCLASS64), byte(elf.ELFDATA2LSB), byte(elf.EV_CURRENT)})
+	program := elf.Prog64{
+		Type: uint32(elf.PT_LOAD), Flags: uint32(elf.PF_R | elf.PF_W),
+		Off: 128, Vaddr: 0x400080, Filesz: uint64(len(info)), Memsz: uint64(len(info)), Align: 16,
+	}
+	var executable bytes.Buffer
+	if err := binary.Write(&executable, binary.LittleEndian, header); err != nil {
+		t.Fatal(err)
+	}
+	if err := binary.Write(&executable, binary.LittleEndian, program); err != nil {
+		t.Fatal(err)
+	}
+	executable.Write(make([]byte, 128-executable.Len()))
+	executable.Write(info)
+	return executable.Bytes()
+}

--- a/.github/actions/verify-release-sboms/platforms_test.go
+++ b/.github/actions/verify-release-sboms/platforms_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReleaseRejectsOmittedConfiguredPlatforms(t *testing.T) {
+	t.Parallel()
+
+	for _, platform := range releasePlatforms {
+		t.Run(platform, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := newReleaseFixture(t)
+			archive := filepath.Join(fixture.directory, "terraform-provider-openai_1.2.3_"+platform+".zip")
+			for _, path := range []string{archive, archive + ".spdx.json"} {
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+			}
+			fixture.writeChecksums(t)
+			err := verifyRelease(fixture.manifest)
+			if err == nil || !strings.Contains(err.Error(), "missing configured platform \""+platform+"\"") {
+				t.Fatalf("incomplete release verification error = %v, want missing configured platform %q", err, platform)
+			}
+		})
+	}
+}

--- a/.github/actions/verify-release-sboms/publication_test.go
+++ b/.github/actions/verify-release-sboms/publication_test.go
@@ -17,9 +17,105 @@ func TestDraftPublicationRejectsUnverifiedRemoteArtifacts(t *testing.T) {
 		draft            bool
 		resignManifest   bool
 		wrongFingerprint bool
+		swapTarget       string
+		swapAfter        string
+		mutateInventory  func([]releaseAsset)
 		wantErr          string
 	}{
 		{name: "valid signed draft", draft: true},
+		{
+			name: "remote asset has no immutable identity",
+			mutateInventory: func(assets []releaseAsset) {
+				assets[0].ID = ""
+			},
+			draft:   true,
+			wantErr: "no immutable uploaded identity and SHA-256 digest",
+		},
+		{
+			name: "remote asset has no immutable digest",
+			mutateInventory: func(assets []releaseAsset) {
+				assets[0].Digest = ""
+			},
+			draft:   true,
+			wantErr: "no immutable uploaded identity and SHA-256 digest",
+		},
+		{
+			name: "remote asset is not completely uploaded",
+			mutateInventory: func(assets []releaseAsset) {
+				assets[0].State = "starter"
+			},
+			draft:   true,
+			wantErr: "no immutable uploaded identity and SHA-256 digest",
+		},
+		{
+			name: "remote asset bytes do not match immutable digest",
+			mutateInventory: func(assets []releaseAsset) {
+				for index := range assets {
+					if assets[index].Name == "terraform-provider-openai_1.2.3_SHA256SUMS" {
+						assets[index].Digest = "sha256:" + strings.Repeat("0", sha256.Size*2)
+					}
+				}
+			},
+			draft:   true,
+			wantErr: "does not match its immutable SHA-256 digest",
+		},
+		{
+			name:       "checksum replaced after verified download",
+			draft:      true,
+			swapTarget: "terraform-provider-openai_1.2.3_SHA256SUMS",
+			swapAfter:  "terraform-provider-openai_1.2.3_SHA256SUMS.sig",
+			wantErr:    "uploaded release assets changed during verification",
+		},
+		{
+			name:       "signature replaced after verified download",
+			draft:      true,
+			swapTarget: "terraform-provider-openai_1.2.3_SHA256SUMS.sig",
+			wantErr:    "uploaded release assets changed during verification",
+		},
+		{
+			name:       "archive replaced after verified download",
+			draft:      true,
+			swapTarget: "terraform-provider-openai_1.2.3_linux_amd64.zip",
+			wantErr:    "uploaded release assets changed during verification",
+		},
+		{
+			name:       "SPDX replaced after verified download",
+			draft:      true,
+			swapTarget: "terraform-provider-openai_1.2.3_linux_amd64.zip.spdx.json",
+			wantErr:    "uploaded release assets changed during verification",
+		},
+		{
+			name:       "registry replaced after verified download",
+			draft:      true,
+			swapTarget: "terraform-provider-openai_1.2.3_manifest.json",
+			wantErr:    "uploaded release assets changed during verification",
+		},
+		{
+			name: "signed release omits a configured platform and both checksum entries",
+			mutate: func(t *testing.T, remote string, fixture releaseFixture) {
+				archive := "terraform-provider-openai_1.2.3_linux_arm64.zip"
+				for _, name := range []string{archive, archive + ".spdx.json"} {
+					if err := os.Remove(filepath.Join(remote, name)); err != nil {
+						t.Fatal(err)
+					}
+				}
+				path := filepath.Join(remote, filepath.Base(fixture.manifest))
+				contents, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var retained []string
+				for _, line := range strings.Split(strings.TrimSuffix(string(contents), "\n"), "\n") {
+					if !strings.HasSuffix(line, "  "+archive) && !strings.HasSuffix(line, "  "+archive+".spdx.json") {
+						retained = append(retained, line)
+					}
+				}
+				writeFixtureFile(t, path, []byte(strings.Join(retained, "\n")+"\n"))
+			},
+			draft:          true,
+			resignManifest: true,
+			wantErr:        "missing configured platform",
+		},
 		{
 			name: "post-sign registry replacement refreshes signed checksums",
 			mutate: func(t *testing.T, remote string, fixture releaseFixture) {
@@ -137,7 +233,11 @@ func TestDraftPublicationRejectsUnverifiedRemoteArtifacts(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fixture := newReleaseFixture(t)
 			remote := t.TempDir()
-			for _, path := range []string{fixture.archive, fixture.archive + ".spdx.json", fixture.manifest} {
+			paths, err := filepath.Glob(filepath.Join(fixture.directory, "*"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, path := range paths {
 				contents, err := os.ReadFile(path)
 				if err != nil {
 					t.Fatal(err)
@@ -175,9 +275,19 @@ func TestDraftPublicationRejectsUnverifiedRemoteArtifacts(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			assets := make([]map[string]string, 0, len(entries))
+			assets := make([]releaseAsset, 0, len(entries))
 			for _, entry := range entries {
-				assets = append(assets, map[string]string{"name": entry.Name()})
+				contents, err := os.ReadFile(filepath.Join(remote, entry.Name()))
+				if err != nil {
+					t.Fatal(err)
+				}
+				assets = append(assets, releaseAsset{
+					Name: entry.Name(), ID: "asset-" + entry.Name(),
+					Digest: fmt.Sprintf("sha256:%x", sha256.Sum256(contents)), State: "uploaded",
+				})
+			}
+			if test.mutateInventory != nil {
+				test.mutateInventory(assets)
 			}
 			description, err := json.Marshal(map[string]any{"tagName": "v1.2.3", "isDraft": test.draft, "assets": assets})
 			if err != nil {
@@ -185,13 +295,40 @@ func TestDraftPublicationRejectsUnverifiedRemoteArtifacts(t *testing.T) {
 			}
 			descriptionPath := filepath.Join(directory, "release.json")
 			writeFixtureFile(t, descriptionPath, description)
+			if test.swapTarget != "" {
+				replacement := []byte("unverified replacement after download")
+				for index := range assets {
+					if assets[index].Name == test.swapTarget {
+						assets[index].ID = "replacement-" + test.swapTarget
+						assets[index].Digest = fmt.Sprintf("sha256:%x", sha256.Sum256(replacement))
+					}
+				}
+				swapped, err := json.Marshal(map[string]any{"tagName": "v1.2.3", "isDraft": test.draft, "assets": assets})
+				if err != nil {
+					t.Fatal(err)
+				}
+				writeFixtureFile(t, filepath.Join(directory, "swapped-release.json"), swapped)
+				writeFixtureFile(t, filepath.Join(directory, "replacement"), replacement)
+			}
 			published := filepath.Join(directory, "published-release")
 
 			gh := filepath.Join(directory, "gh")
 			writeFixtureFile(t, gh, []byte("#!/bin/sh\n"+
 				"if [ \"$1:$2\" = release:view ]; then cat \"$MOCK_RELEASE_DESCRIPTION\"; exit; fi\n"+
 				"if [ \"$1:$2\" = release:edit ]; then printf '%s\\n' \"$@\" > \"$MOCK_PUBLISH_RECORD\"; exit; fi\n"+
-				"if [ \"$1:$2\" = release:download ]; then shift 3; while [ $# -gt 0 ]; do if [ \"$1\" = --pattern ]; then shift; asset=\"$1\"; fi; shift; done; cat \"$MOCK_RELEASE_ASSETS/$asset\"; exit; fi\n"+
+				"if [ \"$1:$2\" = release:download ]; then\n"+
+				"  shift 3\n"+
+				"  while [ $# -gt 0 ]; do\n"+
+				"    if [ \"$1\" = --pattern ]; then shift; asset=\"$1\"; fi\n"+
+				"    shift\n"+
+				"  done\n"+
+				"  cat \"$MOCK_RELEASE_ASSETS/$asset\"\n"+
+				"  if [ \"$asset\" = \"${MOCK_SWAP_AFTER:-}\" ]; then\n"+
+				"    cp \"$MOCK_SWAP_SOURCE\" \"$MOCK_RELEASE_ASSETS/$MOCK_SWAP_TARGET\"\n"+
+				"    cp \"$MOCK_SWAPPED_DESCRIPTION\" \"$MOCK_RELEASE_DESCRIPTION\"\n"+
+				"  fi\n"+
+				"  exit\n"+
+				"fi\n"+
 				"exit 2\n"))
 			gpg := filepath.Join(directory, "gpg")
 			writeFixtureFile(t, gpg, []byte("#!/bin/sh\n"+
@@ -211,6 +348,16 @@ func TestDraftPublicationRejectsUnverifiedRemoteArtifacts(t *testing.T) {
 			t.Setenv("MOCK_EXPECTED_MANIFEST", expectedManifest)
 			t.Setenv("MOCK_EXPECTED_SIGNATURE", expectedSignature)
 			t.Setenv("MOCK_SIGNER", "0123456789ABCDEF0123456789ABCDEF01234567")
+			if test.swapTarget != "" {
+				trigger := test.swapAfter
+				if trigger == "" {
+					trigger = test.swapTarget
+				}
+				t.Setenv("MOCK_SWAP_AFTER", trigger)
+				t.Setenv("MOCK_SWAP_TARGET", test.swapTarget)
+				t.Setenv("MOCK_SWAP_SOURCE", filepath.Join(directory, "replacement"))
+				t.Setenv("MOCK_SWAPPED_DESCRIPTION", filepath.Join(directory, "swapped-release.json"))
+			}
 
 			fingerprint := "0123456789ABCDEF0123456789ABCDEF01234567"
 			if test.wrongFingerprint {
@@ -251,5 +398,5 @@ func replaceRemoteArtifact(t *testing.T, remote string, fixture releaseFixture, 
 	}
 	before := fmt.Sprintf("%x", sha256.Sum256(original))
 	after := fmt.Sprintf("%x", sha256.Sum256(contents))
-	writeFixtureFile(t, manifestPath, []byte(strings.Replace(string(manifest), before, after, 1)))
+	writeFixtureFile(t, manifestPath, []byte(strings.Replace(string(manifest), before+"  "+name, after+"  "+name, 1)))
 }

--- a/.github/actions/verify-release-sboms/publication_test.go
+++ b/.github/actions/verify-release-sboms/publication_test.go
@@ -159,6 +159,44 @@ func TestDraftPublicationRejectsUnverifiedRemoteArtifacts(t *testing.T) {
 			wantErr:        "has no version or packages",
 		},
 		{
+			name: "signed SPDX with forged provider archive identity",
+			mutate: func(t *testing.T, remote string, fixture releaseFixture) {
+				name := filepath.Base(fixture.archive) + ".spdx.json"
+				contents, err := os.ReadFile(filepath.Join(remote, name))
+				if err != nil {
+					t.Fatal(err)
+				}
+				var document map[string]any
+				if err := json.Unmarshal(contents, &document); err != nil {
+					t.Fatal(err)
+				}
+				document["name"] = "attacker-rebound-provider.zip"
+				forged, err := json.Marshal(document)
+				if err != nil {
+					t.Fatal(err)
+				}
+				replaceRemoteArtifact(t, remote, fixture, name, forged)
+			},
+			draft:          true,
+			resignManifest: true,
+			wantErr:        "does not identify archive",
+		},
+		{
+			name: "signed archive replaced after SPDX generation",
+			mutate: func(t *testing.T, remote string, fixture releaseFixture) {
+				name := filepath.Base(fixture.archive)
+				contents, err := os.ReadFile(filepath.Join(remote, name))
+				if err != nil {
+					t.Fatal(err)
+				}
+				replaceRemoteArtifact(t, remote, fixture, name,
+					append(contents, []byte("post-generation replacement")...))
+			},
+			draft:          true,
+			resignManifest: true,
+			wantErr:        "invalid archive identity, SHA-256 digest, or supplier",
+		},
+		{
 			name: "signed unsupported archive platform",
 			mutate: func(t *testing.T, remote string, fixture releaseFixture) {
 				original := filepath.Base(fixture.archive)

--- a/.github/actions/verify-release-sboms/publication_test.go
+++ b/.github/actions/verify-release-sboms/publication_test.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDraftPublicationRejectsUnverifiedRemoteArtifacts(t *testing.T) {
+	tests := []struct {
+		name             string
+		mutate           func(*testing.T, string, releaseFixture)
+		draft            bool
+		resignManifest   bool
+		wrongFingerprint bool
+		wantErr          string
+	}{
+		{name: "valid signed draft", draft: true},
+		{
+			name: "post-sign registry replacement refreshes signed checksums",
+			mutate: func(t *testing.T, remote string, fixture releaseFixture) {
+				replaceRemoteArtifact(t, remote, fixture, "terraform-provider-openai_1.2.3_manifest.json", []byte(`{"version":999,"metadata":{"protocol_versions":["6.0"]}}`))
+			},
+			draft:   true,
+			wantErr: "verify uploaded checksum signature",
+		},
+		{
+			name: "replaced provider archive",
+			mutate: func(t *testing.T, remote string, fixture releaseFixture) {
+				writeFixtureFile(t, filepath.Join(remote, filepath.Base(fixture.archive)), []byte("unverified uploaded provider"))
+			},
+			draft:   true,
+			wantErr: "SHA-256 checksum mismatch",
+		},
+		{
+			name: "malformed uploaded registry metadata",
+			mutate: func(t *testing.T, remote string, _ releaseFixture) {
+				writeFixtureFile(t, filepath.Join(remote, "terraform-provider-openai_1.2.3_manifest.json"), []byte(`{"version":999}`))
+			},
+			draft:   true,
+			wantErr: "SHA-256 checksum mismatch",
+		},
+		{
+			name: "signed malformed Terraform Registry metadata",
+			mutate: func(t *testing.T, remote string, fixture releaseFixture) {
+				replaceRemoteArtifact(t, remote, fixture, "terraform-provider-openai_1.2.3_manifest.json", []byte(`{"version":999,"metadata":{"protocol_versions":["6.0"]}}`))
+			},
+			draft:          true,
+			resignManifest: true,
+			wantErr:        "unsupported version 999",
+		},
+		{
+			name: "signed malformed SPDX document",
+			mutate: func(t *testing.T, remote string, fixture releaseFixture) {
+				replaceRemoteArtifact(t, remote, fixture, filepath.Base(fixture.archive)+".spdx.json", []byte(`{"spdxVersion":"SPDX-2.3","packages":[]}`))
+			},
+			draft:          true,
+			resignManifest: true,
+			wantErr:        "has no version or packages",
+		},
+		{
+			name: "signed unsupported archive platform",
+			mutate: func(t *testing.T, remote string, fixture releaseFixture) {
+				original := filepath.Base(fixture.archive)
+				replacement := "terraform-provider-openai_1.2.3_linux_riscv64.zip"
+				for _, suffix := range []string{"", ".spdx.json"} {
+					if err := os.Rename(filepath.Join(remote, original+suffix), filepath.Join(remote, replacement+suffix)); err != nil {
+						t.Fatal(err)
+					}
+				}
+				path := filepath.Join(remote, filepath.Base(fixture.manifest))
+				manifest, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				writeFixtureFile(t, path, []byte(strings.ReplaceAll(string(manifest), original, replacement)))
+			},
+			draft:          true,
+			resignManifest: true,
+			wantErr:        "unsupported release platform",
+		},
+		{
+			name: "missing detached signature",
+			mutate: func(t *testing.T, remote string, fixture releaseFixture) {
+				if err := os.Remove(filepath.Join(remote, filepath.Base(fixture.manifest)+".sig")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			draft:   true,
+			wantErr: "missing signed checksum artifact",
+		},
+		{
+			name: "forged detached signature",
+			mutate: func(t *testing.T, remote string, fixture releaseFixture) {
+				writeFixtureFile(t, filepath.Join(remote, filepath.Base(fixture.manifest)+".sig"), []byte("untrusted detached signature"))
+			},
+			draft:   true,
+			wantErr: "verify uploaded checksum signature",
+		},
+		{
+			name: "missing uploaded SPDX SBOM",
+			mutate: func(t *testing.T, remote string, fixture releaseFixture) {
+				if err := os.Remove(filepath.Join(remote, filepath.Base(fixture.archive)+".spdx.json")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			draft:   true,
+			wantErr: "has no matching SPDX SBOM",
+		},
+		{
+			name: "missing uploaded Terraform Registry manifest",
+			mutate: func(t *testing.T, remote string, _ releaseFixture) {
+				if err := os.Remove(filepath.Join(remote, "terraform-provider-openai_1.2.3_manifest.json")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			draft:   true,
+			wantErr: "has no Terraform Registry manifest",
+		},
+		{
+			name: "unexpected uploaded artifact",
+			mutate: func(t *testing.T, remote string, _ releaseFixture) {
+				writeFixtureFile(t, filepath.Join(remote, "unverified.json"), []byte("unverified"))
+			},
+			draft:   true,
+			wantErr: "unexpected uploaded release artifact",
+		},
+		{name: "signature from an unexpected GPG key", draft: true, wrongFingerprint: true, wantErr: "verify uploaded checksum signature"},
+		{name: "already public release", wantErr: "not a private draft"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newReleaseFixture(t)
+			remote := t.TempDir()
+			for _, path := range []string{fixture.archive, fixture.archive + ".spdx.json", fixture.manifest} {
+				contents, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				writeFixtureFile(t, filepath.Join(remote, filepath.Base(path)), contents)
+			}
+			registry, err := os.ReadFile(fixture.registry)
+			if err != nil {
+				t.Fatal(err)
+			}
+			writeFixtureFile(t, filepath.Join(remote, "terraform-provider-openai_1.2.3_manifest.json"), registry)
+			writeFixtureFile(t, filepath.Join(remote, filepath.Base(fixture.manifest)+".sig"), []byte("trusted detached signature"))
+
+			directory := t.TempDir()
+			expectedManifest := filepath.Join(directory, "expected-manifest")
+			manifest, err := os.ReadFile(fixture.manifest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			writeFixtureFile(t, expectedManifest, manifest)
+			expectedSignature := filepath.Join(directory, "expected-signature")
+			writeFixtureFile(t, expectedSignature, []byte("trusted detached signature"))
+			if test.mutate != nil {
+				test.mutate(t, remote, fixture)
+			}
+			if test.resignManifest {
+				updated, err := os.ReadFile(filepath.Join(remote, filepath.Base(fixture.manifest)))
+				if err != nil {
+					t.Fatal(err)
+				}
+				writeFixtureFile(t, expectedManifest, updated)
+			}
+
+			entries, err := os.ReadDir(remote)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assets := make([]map[string]string, 0, len(entries))
+			for _, entry := range entries {
+				assets = append(assets, map[string]string{"name": entry.Name()})
+			}
+			description, err := json.Marshal(map[string]any{"tagName": "v1.2.3", "isDraft": test.draft, "assets": assets})
+			if err != nil {
+				t.Fatal(err)
+			}
+			descriptionPath := filepath.Join(directory, "release.json")
+			writeFixtureFile(t, descriptionPath, description)
+			published := filepath.Join(directory, "published-release")
+
+			gh := filepath.Join(directory, "gh")
+			writeFixtureFile(t, gh, []byte("#!/bin/sh\n"+
+				"if [ \"$1:$2\" = release:view ]; then cat \"$MOCK_RELEASE_DESCRIPTION\"; exit; fi\n"+
+				"if [ \"$1:$2\" = release:edit ]; then printf '%s\\n' \"$@\" > \"$MOCK_PUBLISH_RECORD\"; exit; fi\n"+
+				"if [ \"$1:$2\" = release:download ]; then shift 3; while [ $# -gt 0 ]; do if [ \"$1\" = --pattern ]; then shift; asset=\"$1\"; fi; shift; done; cat \"$MOCK_RELEASE_ASSETS/$asset\"; exit; fi\n"+
+				"exit 2\n"))
+			gpg := filepath.Join(directory, "gpg")
+			writeFixtureFile(t, gpg, []byte("#!/bin/sh\n"+
+				"test \"$3\" = \"$MOCK_SIGNER\" || exit 3\n"+
+				"test \"$5\" = /dev/fd/3 || exit 6\n"+
+				"cmp \"$5\" \"$MOCK_EXPECTED_SIGNATURE\" >/dev/null || exit 4\n"+
+				"cmp - \"$MOCK_EXPECTED_MANIFEST\" >/dev/null || exit 5\n"))
+			for _, path := range []string{gh, gpg} {
+				if err := os.Chmod(path, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			t.Setenv("PATH", directory+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("MOCK_RELEASE_DESCRIPTION", descriptionPath)
+			t.Setenv("MOCK_RELEASE_ASSETS", remote)
+			t.Setenv("MOCK_PUBLISH_RECORD", published)
+			t.Setenv("MOCK_EXPECTED_MANIFEST", expectedManifest)
+			t.Setenv("MOCK_EXPECTED_SIGNATURE", expectedSignature)
+			t.Setenv("MOCK_SIGNER", "0123456789ABCDEF0123456789ABCDEF01234567")
+
+			fingerprint := "0123456789ABCDEF0123456789ABCDEF01234567"
+			if test.wrongFingerprint {
+				fingerprint = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+			}
+			err = run([]string{"--publish", "v1.2.3", fingerprint})
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("verified private draft was not published: %v", err)
+				}
+				if _, err := os.Stat(published); err != nil {
+					t.Fatalf("verified private draft did not reach publication: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("publication error = %v, want %q", err, test.wantErr)
+			}
+			if _, err := os.Stat(published); !os.IsNotExist(err) {
+				t.Fatalf("unverified draft became publicly visible: %v", err)
+			}
+		})
+	}
+}
+
+func replaceRemoteArtifact(t *testing.T, remote string, fixture releaseFixture, name string, contents []byte) {
+	t.Helper()
+
+	original, err := os.ReadFile(filepath.Join(remote, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFixtureFile(t, filepath.Join(remote, name), contents)
+	manifestPath := filepath.Join(remote, filepath.Base(fixture.manifest))
+	manifest, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := fmt.Sprintf("%x", sha256.Sum256(original))
+	after := fmt.Sprintf("%x", sha256.Sum256(contents))
+	writeFixtureFile(t, manifestPath, []byte(strings.Replace(string(manifest), before, after, 1)))
+}

--- a/.github/actions/verify-release-sboms/sbom_validation_test.go
+++ b/.github/actions/verify-release-sboms/sbom_validation_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSigningRejectsReplacedInternallyChecksummedSBOM(t *testing.T) {
+	fixture := newReleaseFixture(t)
+	writeFixtureFile(t, fixture.archive+".spdx.json", []byte(`{"spdxVersion":"SPDX-2.3","name":"attacker-rebound-provider","packages":[{"name":"attacker-controlled"}]}`))
+	fixture.writeChecksums(t)
+
+	if err := verifyRelease(fixture.manifest); err == nil || !strings.Contains(err.Error(), "SPDX") {
+		t.Fatalf("internally checksummed replacement SBOM was not rejected: %v", err)
+	}
+}
+
+func TestSigningRejectsArchiveReplacedAfterSBOMGeneration(t *testing.T) {
+	fixture := newReleaseFixture(t)
+	archive, err := os.ReadFile(fixture.archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFixtureFile(t, fixture.archive, append(archive, []byte("post-generation replacement")...))
+	fixture.writeChecksums(t)
+
+	err = verifyRelease(fixture.manifest)
+	if err == nil || !strings.Contains(err.Error(), "invalid archive identity, SHA-256 digest, or supplier") {
+		t.Fatalf("internally checksummed archive replacement was not rejected: %v", err)
+	}
+}
+
+func TestSigningRevalidatesCompleteArchiveSBOM(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(map[string]any)
+		wantErr string
+	}{
+		{
+			name: "document archive identity",
+			mutate: func(document map[string]any) {
+				document["name"] = "attacker-rebound-provider.zip"
+			},
+			wantErr: "does not identify archive",
+		},
+		{
+			name: "missing described archive",
+			mutate: func(document map[string]any) {
+				document["relationships"] = []any{}
+			},
+			wantErr: "does not describe its provider archive",
+		},
+		{
+			name: "multiple described archives",
+			mutate: func(document map[string]any) {
+				relationships := document["relationships"].([]any)
+				document["relationships"] = append(relationships, relationships[0])
+			},
+			wantErr: "describes more than one provider archive",
+		},
+		{
+			name: "provider archive identity",
+			mutate: func(document map[string]any) {
+				document["packages"].([]any)[0].(map[string]any)["name"] = "attacker-rebound-provider.zip"
+			},
+			wantErr: "invalid archive identity",
+		},
+		{
+			name: "provider archive digest",
+			mutate: func(document map[string]any) {
+				document["packages"].([]any)[0].(map[string]any)["versionInfo"] = "sha256:attacker-controlled"
+			},
+			wantErr: "invalid archive identity",
+		},
+		{
+			name: "provider source supplier",
+			mutate: func(document map[string]any) {
+				document["packages"].([]any)[0].(map[string]any)["supplier"] = "Attacker Controlled"
+			},
+			wantErr: "invalid archive identity",
+		},
+		{
+			name: "missing provider archive package",
+			mutate: func(document map[string]any) {
+				document["packages"].([]any)[0].(map[string]any)["SPDXID"] = "SPDXRef-attacker"
+			},
+			wantErr: "no matching provider archive package",
+		},
+		{
+			name: "missing provider dependency",
+			mutate: func(document map[string]any) {
+				document["packages"] = document["packages"].([]any)[:2]
+			},
+			wantErr: "omits provider dependency",
+		},
+		{
+			name: "forged provider dependency version",
+			mutate: func(document map[string]any) {
+				document["packages"].([]any)[2].(map[string]any)["versionInfo"] = "v999.999.999"
+			},
+			wantErr: "omits provider dependency",
+		},
+		{
+			name: "forged OpenAI SDK license",
+			mutate: func(document map[string]any) {
+				document["packages"].([]any)[1].(map[string]any)["licenseConcluded"] = "MIT"
+			},
+			wantErr: "no Apache-2.0 OpenAI SDK package",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newReleaseFixture(t)
+			mutateFixtureSBOM(t, fixture, test.mutate)
+
+			directory := t.TempDir()
+			record := filepath.Join(directory, "signing-record")
+			gpg := filepath.Join(directory, "gpg")
+			writeFixtureFile(t, gpg, []byte("#!/bin/sh\nprintf 'signed\\n' > \"$SIGNING_RECORD\"\n"))
+			if err := os.Chmod(gpg, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", directory+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("SIGNING_RECORD", record)
+
+			err := run([]string{fixture.manifest, "--sign", "--batch", "--detach-sign", fixture.manifest})
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("signing error = %v, want %q", err, test.wantErr)
+			}
+			if _, err := os.Stat(record); !os.IsNotExist(err) {
+				t.Fatalf("unverified SBOM reached production GPG signing: %v", err)
+			}
+		})
+	}
+}
+
+func mutateFixtureSBOM(t *testing.T, fixture releaseFixture, mutate func(map[string]any)) {
+	t.Helper()
+
+	contents, err := os.ReadFile(fixture.archive + ".spdx.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(contents, &document); err != nil {
+		t.Fatal(err)
+	}
+	mutate(document)
+	updated, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFixtureFile(t, fixture.archive+".spdx.json", updated)
+	fixture.writeChecksums(t)
+}
+
+func TestGPGVerificationFailureRedactsSignerIdentity(t *testing.T) {
+	directory := t.TempDir()
+	gpg := filepath.Join(directory, "gpg")
+	writeFixtureFile(t, gpg, []byte("#!/bin/sh\n"+
+		"printf 'gpg: Good signature from \"Synthetic Release Signer <signer@example.invalid>\"\\n' >&2\n"+
+		"printf 'gpg: using EDDSA key ABCDEF0123456789ABCDEF0123456789ABCDEF01\\n' >&2\n"+
+		"exit 1\n"))
+	if err := os.Chmod(gpg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", directory+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	err := verifyReleaseSignature([]byte("signed checksum manifest"), []byte("signature"), "UNEXPECTED-FINGERPRINT")
+	if err == nil {
+		t.Fatal("unexpected signer identity was accepted")
+	}
+	for _, sensitive := range []string{"signer@example.invalid", "Synthetic Release Signer", "ABCDEF0123456789"} {
+		if strings.Contains(err.Error(), sensitive) {
+			t.Fatalf("GPG verification failure exposes signer identity %q: %v", sensitive, err)
+		}
+	}
+}

--- a/.github/actions/verify-release-sboms/verify.go
+++ b/.github/actions/verify-release-sboms/verify.go
@@ -31,25 +31,39 @@ func run(args []string) error {
 		return errors.New("signing target does not match verified checksum manifest")
 	}
 
-	if err := verifyRelease(args[0]); err != nil {
+	manifest, mode, err := readChecksumSnapshot(args[0])
+	if err != nil {
+		return err
+	}
+	if err := verifyReleaseSnapshot(args[0], manifest); err != nil {
 		return err
 	}
 	if len(args) == 1 {
 		return nil
 	}
 
-	sign := exec.Command("gpg", args[2:]...)
-	sign.Stdin = os.Stdin
+	signingArguments := append([]string(nil), args[2:]...)
+	signingArguments[len(signingArguments)-1] = "-"
+	sign := exec.Command("gpg", signingArguments...)
+	sign.Stdin = bytes.NewReader(manifest)
 	sign.Stdout = os.Stdout
 	sign.Stderr = os.Stderr
 	if err := sign.Run(); err != nil {
 		return fmt.Errorf("sign verified checksum manifest: %w", err)
 	}
-	return nil
+	return publishVerifiedChecksums(args[0], manifest, mode)
 }
 
 func verifyRelease(checksumPath string) error {
-	checksums, err := readChecksums(checksumPath)
+	manifest, _, err := readChecksumSnapshot(checksumPath)
+	if err != nil {
+		return err
+	}
+	return verifyReleaseSnapshot(checksumPath, manifest)
+}
+
+func verifyReleaseSnapshot(checksumPath string, manifest []byte) error {
+	checksums, err := readChecksums(manifest)
 	if err != nil {
 		return err
 	}
@@ -96,6 +110,10 @@ func verifyRelease(checksumPath string) error {
 	if !valid || releaseName == "" {
 		return fmt.Errorf("checksum manifest %q has no release identity", filepath.Base(checksumPath))
 	}
+	version, valid := strings.CutPrefix(releaseName, "terraform-provider-openai_")
+	if !valid || version == "" {
+		return fmt.Errorf("checksum manifest %q has an unsupported provider release identity", filepath.Base(checksumPath))
+	}
 	registryName := releaseName + "_manifest.json"
 	registryPath := filepath.Join(filepath.Dir(filepath.Dir(checksumPath)), "terraform-registry-manifest.json")
 	if err := verifyArtifact(registryName, registryPath, checksums); err != nil {
@@ -106,6 +124,9 @@ func verifyRelease(checksumPath string) error {
 	}
 
 	for name, path := range archives {
+		if err := verifyReleasePlatform(name, releaseName); err != nil {
+			return err
+		}
 		sbomName := name + ".spdx.json"
 		sbomPath, exists := sboms[sbomName]
 		if !exists || sbomPath != path+".spdx.json" {
@@ -140,12 +161,32 @@ func verifyRelease(checksumPath string) error {
 	return nil
 }
 
-func readChecksums(path string) (map[string][]byte, error) {
-	manifest, err := os.ReadFile(path)
+func readChecksumSnapshot(path string) ([]byte, fs.FileMode, error) {
+	file, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("read checksum manifest: %w", err)
+		return nil, 0, fmt.Errorf("read checksum manifest: %w", err)
 	}
+	info, statErr := file.Stat()
+	if statErr != nil {
+		_ = file.Close()
+		return nil, 0, fmt.Errorf("inspect checksum manifest: %w", statErr)
+	}
+	if !info.Mode().IsRegular() {
+		_ = file.Close()
+		return nil, 0, errors.New("checksum manifest is not a regular file")
+	}
+	manifest, readErr := io.ReadAll(file)
+	closeErr := file.Close()
+	if readErr != nil {
+		return nil, 0, fmt.Errorf("read checksum manifest: %w", readErr)
+	}
+	if closeErr != nil {
+		return nil, 0, fmt.Errorf("close checksum manifest: %w", closeErr)
+	}
+	return manifest, info.Mode().Perm(), nil
+}
 
+func readChecksums(manifest []byte) (map[string][]byte, error) {
 	checksums := make(map[string][]byte)
 	scanner := bufio.NewScanner(bytes.NewReader(manifest))
 	for scanner.Scan() {
@@ -173,6 +214,52 @@ func readChecksums(path string) (map[string][]byte, error) {
 		return nil, fmt.Errorf("read checksum manifest: %w", err)
 	}
 	return checksums, nil
+}
+
+func publishVerifiedChecksums(path string, manifest []byte, mode fs.FileMode) error {
+	snapshot, err := os.CreateTemp(filepath.Dir(path), ".verified-checksums-*")
+	if err != nil {
+		return fmt.Errorf("create verified checksum snapshot: %w", err)
+	}
+	defer func() {
+		_ = os.Remove(snapshot.Name())
+	}()
+	if err := snapshot.Chmod(mode); err != nil {
+		_ = snapshot.Close()
+		return fmt.Errorf("set verified checksum permissions: %w", err)
+	}
+	_, writeErr := snapshot.Write(manifest)
+	closeErr := snapshot.Close()
+	if writeErr != nil {
+		return fmt.Errorf("write verified checksum snapshot: %w", writeErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close verified checksum snapshot: %w", closeErr)
+	}
+	if err := os.Rename(snapshot.Name(), path); err != nil {
+		return fmt.Errorf("publish verified checksum snapshot: %w", err)
+	}
+	return nil
+}
+
+func verifyReleasePlatform(name, releaseName string) error {
+	archive, valid := strings.CutSuffix(name, ".zip")
+	if !valid {
+		return fmt.Errorf("archive %q is not a ZIP release artifact", name)
+	}
+	platform, valid := strings.CutPrefix(archive, releaseName+"_")
+	if !valid {
+		return fmt.Errorf("archive %q does not belong to release %q", name, releaseName)
+	}
+	switch platform {
+	case "darwin_amd64", "darwin_arm64",
+		"freebsd_386", "freebsd_amd64", "freebsd_arm", "freebsd_arm64",
+		"linux_386", "linux_amd64", "linux_arm", "linux_arm64",
+		"windows_386", "windows_amd64", "windows_arm64":
+		return nil
+	default:
+		return fmt.Errorf("archive %q has unsupported release platform %q", name, platform)
+	}
 }
 
 func verifyArtifact(name, path string, checksums map[string][]byte) error {

--- a/.github/actions/verify-release-sboms/verify.go
+++ b/.github/actions/verify-release-sboms/verify.go
@@ -24,6 +24,12 @@ func main() {
 }
 
 func run(args []string) error {
+	if len(args) > 0 && args[0] == "--publish" {
+		if len(args) != 3 {
+			return errors.New("usage: verify.go --publish RELEASE_TAG SIGNING_FINGERPRINT")
+		}
+		return publishReleaseDraft(args[1], args[2])
+	}
 	if len(args) == 0 || len(args) > 1 && (args[1] != "--sign" || len(args) == 2) {
 		return errors.New("usage: verify.go CHECKSUM_FILE [--sign GPG_ARGS...]")
 	}
@@ -272,19 +278,26 @@ type verifiedArtifact struct {
 }
 
 func verifyArtifact(name, path string, checksums map[string][]byte) (verifiedArtifact, error) {
-	expected, exists := checksums[name]
-	if !exists {
-		return verifiedArtifact{}, fmt.Errorf("checksum manifest has no entry for %q", name)
-	}
 	contents, mode, err := readArtifactSnapshot(path)
 	if err != nil {
 		return verifiedArtifact{}, fmt.Errorf("open release artifact %q: %w", name, err)
 	}
-	digest := sha256.Sum256(contents)
-	if !bytes.Equal(digest[:], expected) {
-		return verifiedArtifact{}, fmt.Errorf("SHA-256 checksum mismatch for %q", name)
+	if err := verifyArtifactContents(name, contents, checksums); err != nil {
+		return verifiedArtifact{}, err
 	}
 	return verifiedArtifact{name: name, path: path, contents: contents, mode: mode}, nil
+}
+
+func verifyArtifactContents(name string, contents []byte, checksums map[string][]byte) error {
+	expected, exists := checksums[name]
+	if !exists {
+		return fmt.Errorf("checksum manifest has no entry for %q", name)
+	}
+	digest := sha256.Sum256(contents)
+	if !bytes.Equal(digest[:], expected) {
+		return fmt.Errorf("SHA-256 checksum mismatch for %q", name)
+	}
+	return nil
 }
 
 func verifyMetadataArtifact(name, path string, checksums map[string][]byte, validate func(string, []byte) error) (verifiedArtifact, error) {
@@ -341,6 +354,165 @@ func verifyRegistryManifest(path string, document []byte) error {
 			return fmt.Errorf("terraform registry manifest %q has duplicate protocol version %q", path, version)
 		}
 		versions[version] = struct{}{}
+	}
+	return nil
+}
+
+func publishReleaseDraft(tag, fingerprint string) error {
+	assets, err := readDraftAssets(tag)
+	if err != nil {
+		return err
+	}
+	releaseName := "terraform-provider-openai_" + strings.TrimPrefix(tag, "v")
+	checksumName := releaseName + "_SHA256SUMS"
+	signatureName := checksumName + ".sig"
+	for _, name := range []string{checksumName, signatureName} {
+		if _, exists := assets[name]; !exists {
+			return fmt.Errorf("missing signed checksum artifact %q", name)
+		}
+	}
+
+	manifest, err := downloadReleaseAsset(tag, checksumName)
+	if err != nil {
+		return err
+	}
+	signature, err := downloadReleaseAsset(tag, signatureName)
+	if err != nil {
+		return err
+	}
+	if err := verifyReleaseSignature(manifest, signature, fingerprint); err != nil {
+		return err
+	}
+	checksums, err := readChecksums(manifest)
+	if err != nil {
+		return err
+	}
+	if err := verifyDraftArtifacts(tag, releaseName, assets, checksums); err != nil {
+		return err
+	}
+	if output, err := exec.Command("gh", "release", "edit", tag, "--draft=false").CombinedOutput(); err != nil {
+		return fmt.Errorf("publish verified release draft: %w: %s", err, bytes.TrimSpace(output))
+	}
+	return nil
+}
+
+func readDraftAssets(tag string) (map[string]struct{}, error) {
+	output, err := exec.Command("gh", "release", "view", tag, "--json", "tagName,isDraft,assets").Output()
+	if err != nil {
+		return nil, fmt.Errorf("inspect private release draft: %w", err)
+	}
+	var release struct {
+		TagName string `json:"tagName"`
+		Draft   bool   `json:"isDraft"`
+		Assets  []struct {
+			Name string `json:"name"`
+		} `json:"assets"`
+	}
+	if err := json.Unmarshal(output, &release); err != nil {
+		return nil, fmt.Errorf("parse private release draft: %w", err)
+	}
+	if release.TagName != tag || !release.Draft {
+		return nil, fmt.Errorf("release %q is not a private draft for the requested tag", tag)
+	}
+
+	assets := make(map[string]struct{}, len(release.Assets))
+	for _, asset := range release.Assets {
+		if filepath.Base(asset.Name) != asset.Name || strings.Contains(asset.Name, "\\") {
+			return nil, fmt.Errorf("uploaded release asset %q is not an artifact filename", asset.Name)
+		}
+		if _, exists := assets[asset.Name]; exists {
+			return nil, fmt.Errorf("duplicate uploaded release artifact %q", asset.Name)
+		}
+		assets[asset.Name] = struct{}{}
+	}
+	return assets, nil
+}
+
+func verifyDraftArtifacts(tag, releaseName string, assets map[string]struct{}, checksums map[string][]byte) error {
+	registryName := releaseName + "_manifest.json"
+	checksumName := releaseName + "_SHA256SUMS"
+	signatureName := checksumName + ".sig"
+	archives := 0
+	sboms := 0
+	for name := range assets {
+		if name == checksumName || name == signatureName {
+			continue
+		}
+		if name != registryName && !strings.HasSuffix(name, ".zip") && !strings.HasSuffix(name, ".spdx.json") {
+			return fmt.Errorf("unexpected uploaded release artifact %q", name)
+		}
+		contents, err := downloadReleaseAsset(tag, name)
+		if err != nil {
+			return err
+		}
+		if err := verifyArtifactContents(name, contents, checksums); err != nil {
+			return err
+		}
+		switch {
+		case name == registryName:
+			if err := verifyRegistryManifest(name, contents); err != nil {
+				return err
+			}
+		case strings.HasSuffix(name, ".zip"):
+			if err := verifyReleasePlatform(name, releaseName); err != nil {
+				return err
+			}
+			if _, exists := assets[name+".spdx.json"]; !exists {
+				return fmt.Errorf("uploaded archive %q has no matching SPDX SBOM", name)
+			}
+			archives++
+		case strings.HasSuffix(name, ".spdx.json"):
+			if err := verifySPDX(name, contents); err != nil {
+				return err
+			}
+			if _, exists := assets[strings.TrimSuffix(name, ".spdx.json")]; !exists {
+				return fmt.Errorf("uploaded SPDX SBOM %q has no matching archive", name)
+			}
+			sboms++
+		default:
+			return fmt.Errorf("unexpected uploaded release artifact %q", name)
+		}
+	}
+	if _, exists := assets[registryName]; !exists {
+		return fmt.Errorf("uploaded release has no Terraform Registry manifest %q", registryName)
+	}
+	if archives == 0 || archives != sboms || len(checksums) != len(assets)-2 {
+		return fmt.Errorf("uploaded release has an incomplete signed artifact set: archives=%d SBOMs=%d checksums=%d", archives, sboms, len(checksums))
+	}
+	return nil
+}
+
+func downloadReleaseAsset(tag, name string) ([]byte, error) {
+	contents, err := exec.Command("gh", "release", "download", tag, "--pattern", name, "--output", "-").Output()
+	if err != nil {
+		return nil, fmt.Errorf("download uploaded release artifact %q: %w", name, err)
+	}
+	return contents, nil
+}
+
+func verifyReleaseSignature(manifest, signature []byte, fingerprint string) error {
+	file, err := os.CreateTemp("", "verified-release-signature-*")
+	if err != nil {
+		return fmt.Errorf("create uploaded signature snapshot: %w", err)
+	}
+	defer func() {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+	}()
+	if _, err := file.Write(signature); err != nil {
+		return fmt.Errorf("write uploaded signature snapshot: %w", err)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rewind uploaded signature snapshot: %w", err)
+	}
+	if err := os.Remove(file.Name()); err != nil {
+		return fmt.Errorf("seal uploaded signature snapshot: %w", err)
+	}
+	verify := exec.Command("gpg", "--batch", "--assert-signer", fingerprint, "--verify", "/dev/fd/3", "-")
+	verify.ExtraFiles = []*os.File{file}
+	verify.Stdin = bytes.NewReader(manifest)
+	if output, err := verify.CombinedOutput(); err != nil {
+		return fmt.Errorf("verify uploaded checksum signature: %w: %s", err, bytes.TrimSpace(output))
 	}
 	return nil
 }

--- a/.github/actions/verify-release-sboms/verify.go
+++ b/.github/actions/verify-release-sboms/verify.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	if len(args) == 0 || len(args) > 1 && (args[1] != "--sign" || len(args) == 2) {
+		return errors.New("usage: verify.go CHECKSUM_FILE [--sign GPG_ARGS...]")
+	}
+	if len(args) > 1 && args[len(args)-1] != args[0] {
+		return errors.New("signing target does not match verified checksum manifest")
+	}
+
+	if err := verifyRelease(args[0]); err != nil {
+		return err
+	}
+	if len(args) == 1 {
+		return nil
+	}
+
+	sign := exec.Command("gpg", args[2:]...)
+	sign.Stdin = os.Stdin
+	sign.Stdout = os.Stdout
+	sign.Stderr = os.Stderr
+	if err := sign.Run(); err != nil {
+		return fmt.Errorf("sign verified checksum manifest: %w", err)
+	}
+	return nil
+}
+
+func verifyRelease(checksumPath string) error {
+	checksums, err := readChecksums(checksumPath)
+	if err != nil {
+		return err
+	}
+
+	archives := make(map[string]string)
+	sboms := make(map[string]string)
+	if err := filepath.WalkDir(filepath.Dir(checksumPath), func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+
+		var artifacts map[string]string
+		switch {
+		case strings.HasSuffix(entry.Name(), ".zip"):
+			artifacts = archives
+		case strings.HasSuffix(entry.Name(), ".spdx.json"):
+			artifacts = sboms
+		default:
+			return nil
+		}
+		if !entry.Type().IsRegular() {
+			return fmt.Errorf("release artifact %q is not a regular file", path)
+		}
+		if _, exists := artifacts[entry.Name()]; exists {
+			return fmt.Errorf("duplicate release artifact name %q", entry.Name())
+		}
+		artifacts[entry.Name()] = path
+		return nil
+	}); err != nil {
+		return fmt.Errorf("discover release artifacts: %w", err)
+	}
+
+	if len(archives) == 0 {
+		return errors.New("release contains no provider archives")
+	}
+	if len(sboms) != len(archives) {
+		return fmt.Errorf("release has %d archives but %d SBOMs", len(archives), len(sboms))
+	}
+
+	for name, path := range archives {
+		sbomName := name + ".spdx.json"
+		sbomPath, exists := sboms[sbomName]
+		if !exists || sbomPath != path+".spdx.json" {
+			return fmt.Errorf("archive %q has no matching adjacent SBOM", name)
+		}
+		if err := verifyArtifact(name, path, checksums); err != nil {
+			return err
+		}
+		if err := verifyArtifact(sbomName, sbomPath, checksums); err != nil {
+			return err
+		}
+		if err := verifySPDX(sbomPath); err != nil {
+			return err
+		}
+	}
+
+	for name := range checksums {
+		switch {
+		case strings.HasSuffix(name, ".zip"):
+			if _, exists := archives[name]; !exists {
+				return fmt.Errorf("checksum manifest lists missing archive %q", name)
+			}
+		case strings.HasSuffix(name, ".spdx.json"):
+			if _, exists := sboms[name]; !exists {
+				return fmt.Errorf("checksum manifest lists missing SBOM %q", name)
+			}
+		}
+	}
+	return nil
+}
+
+func readChecksums(path string) (map[string][]byte, error) {
+	manifest, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read checksum manifest: %w", err)
+	}
+
+	checksums := make(map[string][]byte)
+	scanner := bufio.NewScanner(bytes.NewReader(manifest))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if len(line) < sha256.Size*2+3 || line[sha256.Size*2] != ' ' ||
+			line[sha256.Size*2+1] != ' ' && line[sha256.Size*2+1] != '*' {
+			return nil, fmt.Errorf("malformed SHA-256 checksum manifest entry %q", line)
+		}
+
+		name := line[sha256.Size*2+2:]
+		if filepath.Base(name) != name || strings.Contains(name, "\\") {
+			return nil, fmt.Errorf("checksum manifest entry %q is not an artifact filename", name)
+		}
+		if _, exists := checksums[name]; exists {
+			return nil, fmt.Errorf("duplicate checksum manifest entry for %q", name)
+		}
+
+		digest, err := hex.DecodeString(line[:sha256.Size*2])
+		if err != nil {
+			return nil, fmt.Errorf("invalid SHA-256 digest for %q: %w", name, err)
+		}
+		checksums[name] = digest
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read checksum manifest: %w", err)
+	}
+	return checksums, nil
+}
+
+func verifyArtifact(name, path string, checksums map[string][]byte) error {
+	expected, exists := checksums[name]
+	if !exists {
+		return fmt.Errorf("checksum manifest has no entry for %q", name)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open release artifact %q: %w", name, err)
+	}
+
+	hash := sha256.New()
+	_, hashErr := io.Copy(hash, file)
+	closeErr := file.Close()
+	if hashErr != nil {
+		return fmt.Errorf("hash release artifact %q: %w", name, hashErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close release artifact %q: %w", name, closeErr)
+	}
+	if !bytes.Equal(hash.Sum(nil), expected) {
+		return fmt.Errorf("SHA-256 checksum mismatch for %q", name)
+	}
+	return nil
+}
+
+func verifySPDX(path string) error {
+	document, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read SBOM %q: %w", path, err)
+	}
+
+	var spdx struct {
+		Version  string            `json:"spdxVersion"`
+		Packages []json.RawMessage `json:"packages"`
+	}
+	if err := json.Unmarshal(document, &spdx); err != nil {
+		return fmt.Errorf("parse SPDX SBOM %q: %w", path, err)
+	}
+	if spdx.Version == "" || len(spdx.Packages) == 0 {
+		return fmt.Errorf("SPDX SBOM %q has no version or packages", path)
+	}
+	return nil
+}

--- a/.github/actions/verify-release-sboms/verify.go
+++ b/.github/actions/verify-release-sboms/verify.go
@@ -166,7 +166,10 @@ func verifyReleaseSnapshot(checksumPath string, manifest []byte, artifacts *[]ve
 			return fmt.Errorf("unexpected checksum manifest entry %q", name)
 		}
 	}
-	return nil
+	return verifyCompleteReleasePlatforms(releaseName, func(name string) bool {
+		_, exists := archives[name]
+		return exists
+	})
 }
 
 func readArtifactSnapshot(path string) ([]byte, fs.FileMode, error) {
@@ -250,6 +253,13 @@ func publishVerifiedSnapshot(path string, contents []byte, mode fs.FileMode) err
 	return nil
 }
 
+var releasePlatforms = [...]string{
+	"darwin_amd64", "darwin_arm64",
+	"freebsd_386", "freebsd_amd64", "freebsd_arm", "freebsd_arm64",
+	"linux_386", "linux_amd64", "linux_arm", "linux_arm64",
+	"windows_386", "windows_amd64", "windows_arm64",
+}
+
 func verifyReleasePlatform(name, releaseName string) error {
 	archive, valid := strings.CutSuffix(name, ".zip")
 	if !valid {
@@ -259,15 +269,21 @@ func verifyReleasePlatform(name, releaseName string) error {
 	if !valid {
 		return fmt.Errorf("archive %q does not belong to release %q", name, releaseName)
 	}
-	switch platform {
-	case "darwin_amd64", "darwin_arm64",
-		"freebsd_386", "freebsd_amd64", "freebsd_arm", "freebsd_arm64",
-		"linux_386", "linux_amd64", "linux_arm", "linux_arm64",
-		"windows_386", "windows_amd64", "windows_arm64":
-		return nil
-	default:
-		return fmt.Errorf("archive %q has unsupported release platform %q", name, platform)
+	for _, supported := range releasePlatforms {
+		if platform == supported {
+			return nil
+		}
 	}
+	return fmt.Errorf("archive %q has unsupported release platform %q", name, platform)
+}
+
+func verifyCompleteReleasePlatforms(releaseName string, exists func(string) bool) error {
+	for _, platform := range releasePlatforms {
+		if !exists(releaseName + "_" + platform + ".zip") {
+			return fmt.Errorf("release is missing configured platform %q", platform)
+		}
+	}
+	return nil
 }
 
 type verifiedArtifact struct {
@@ -372,11 +388,11 @@ func publishReleaseDraft(tag, fingerprint string) error {
 		}
 	}
 
-	manifest, err := downloadReleaseAsset(tag, checksumName)
+	manifest, err := downloadReleaseAsset(tag, assets[checksumName])
 	if err != nil {
 		return err
 	}
-	signature, err := downloadReleaseAsset(tag, signatureName)
+	signature, err := downloadReleaseAsset(tag, assets[signatureName])
 	if err != nil {
 		return err
 	}
@@ -390,23 +406,40 @@ func publishReleaseDraft(tag, fingerprint string) error {
 	if err := verifyDraftArtifacts(tag, releaseName, assets, checksums); err != nil {
 		return err
 	}
+	current, err := readDraftAssets(tag)
+	if err != nil {
+		return err
+	}
+	if len(current) != len(assets) {
+		return errors.New("uploaded release assets changed during verification")
+	}
+	for name, asset := range assets {
+		if current[name] != asset {
+			return errors.New("uploaded release assets changed during verification")
+		}
+	}
 	if output, err := exec.Command("gh", "release", "edit", tag, "--draft=false").CombinedOutput(); err != nil {
 		return fmt.Errorf("publish verified release draft: %w: %s", err, bytes.TrimSpace(output))
 	}
 	return nil
 }
 
-func readDraftAssets(tag string) (map[string]struct{}, error) {
+type releaseAsset struct {
+	Name   string `json:"name"`
+	ID     string `json:"id"`
+	Digest string `json:"digest"`
+	State  string `json:"state"`
+}
+
+func readDraftAssets(tag string) (map[string]releaseAsset, error) {
 	output, err := exec.Command("gh", "release", "view", tag, "--json", "tagName,isDraft,assets").Output()
 	if err != nil {
 		return nil, fmt.Errorf("inspect private release draft: %w", err)
 	}
 	var release struct {
-		TagName string `json:"tagName"`
-		Draft   bool   `json:"isDraft"`
-		Assets  []struct {
-			Name string `json:"name"`
-		} `json:"assets"`
+		TagName string         `json:"tagName"`
+		Draft   bool           `json:"isDraft"`
+		Assets  []releaseAsset `json:"assets"`
 	}
 	if err := json.Unmarshal(output, &release); err != nil {
 		return nil, fmt.Errorf("parse private release draft: %w", err)
@@ -415,7 +448,7 @@ func readDraftAssets(tag string) (map[string]struct{}, error) {
 		return nil, fmt.Errorf("release %q is not a private draft for the requested tag", tag)
 	}
 
-	assets := make(map[string]struct{}, len(release.Assets))
+	assets := make(map[string]releaseAsset, len(release.Assets))
 	for _, asset := range release.Assets {
 		if filepath.Base(asset.Name) != asset.Name || strings.Contains(asset.Name, "\\") {
 			return nil, fmt.Errorf("uploaded release asset %q is not an artifact filename", asset.Name)
@@ -423,25 +456,30 @@ func readDraftAssets(tag string) (map[string]struct{}, error) {
 		if _, exists := assets[asset.Name]; exists {
 			return nil, fmt.Errorf("duplicate uploaded release artifact %q", asset.Name)
 		}
-		assets[asset.Name] = struct{}{}
+		digest, valid := strings.CutPrefix(asset.Digest, "sha256:")
+		decoded, err := hex.DecodeString(digest)
+		if asset.ID == "" || asset.State != "uploaded" || !valid || err != nil || len(decoded) != sha256.Size {
+			return nil, fmt.Errorf("uploaded release artifact %q has no immutable uploaded identity and SHA-256 digest", asset.Name)
+		}
+		assets[asset.Name] = asset
 	}
 	return assets, nil
 }
 
-func verifyDraftArtifacts(tag, releaseName string, assets map[string]struct{}, checksums map[string][]byte) error {
+func verifyDraftArtifacts(tag, releaseName string, assets map[string]releaseAsset, checksums map[string][]byte) error {
 	registryName := releaseName + "_manifest.json"
 	checksumName := releaseName + "_SHA256SUMS"
 	signatureName := checksumName + ".sig"
 	archives := 0
 	sboms := 0
-	for name := range assets {
+	for name, asset := range assets {
 		if name == checksumName || name == signatureName {
 			continue
 		}
 		if name != registryName && !strings.HasSuffix(name, ".zip") && !strings.HasSuffix(name, ".spdx.json") {
 			return fmt.Errorf("unexpected uploaded release artifact %q", name)
 		}
-		contents, err := downloadReleaseAsset(tag, name)
+		contents, err := downloadReleaseAsset(tag, asset)
 		if err != nil {
 			return err
 		}
@@ -479,13 +517,19 @@ func verifyDraftArtifacts(tag, releaseName string, assets map[string]struct{}, c
 	if archives == 0 || archives != sboms || len(checksums) != len(assets)-2 {
 		return fmt.Errorf("uploaded release has an incomplete signed artifact set: archives=%d SBOMs=%d checksums=%d", archives, sboms, len(checksums))
 	}
-	return nil
+	return verifyCompleteReleasePlatforms(releaseName, func(name string) bool {
+		_, exists := assets[name]
+		return exists
+	})
 }
 
-func downloadReleaseAsset(tag, name string) ([]byte, error) {
-	contents, err := exec.Command("gh", "release", "download", tag, "--pattern", name, "--output", "-").Output()
+func downloadReleaseAsset(tag string, asset releaseAsset) ([]byte, error) {
+	contents, err := exec.Command("gh", "release", "download", tag, "--pattern", asset.Name, "--output", "-").Output()
 	if err != nil {
-		return nil, fmt.Errorf("download uploaded release artifact %q: %w", name, err)
+		return nil, fmt.Errorf("download uploaded release artifact %q: %w", asset.Name, err)
+	}
+	if fmt.Sprintf("sha256:%x", sha256.Sum256(contents)) != asset.Digest {
+		return nil, fmt.Errorf("uploaded release artifact %q does not match its immutable SHA-256 digest", asset.Name)
 	}
 	return contents, nil
 }

--- a/.github/actions/verify-release-sboms/verify.go
+++ b/.github/actions/verify-release-sboms/verify.go
@@ -31,11 +31,12 @@ func run(args []string) error {
 		return errors.New("signing target does not match verified checksum manifest")
 	}
 
-	manifest, mode, err := readChecksumSnapshot(args[0])
+	manifest, mode, err := readArtifactSnapshot(args[0])
 	if err != nil {
 		return err
 	}
-	if err := verifyReleaseSnapshot(args[0], manifest); err != nil {
+	var metadata []verifiedArtifact
+	if err := verifyReleaseSnapshot(args[0], manifest, &metadata); err != nil {
 		return err
 	}
 	if len(args) == 1 {
@@ -51,18 +52,19 @@ func run(args []string) error {
 	if err := sign.Run(); err != nil {
 		return fmt.Errorf("sign verified checksum manifest: %w", err)
 	}
-	return publishVerifiedChecksums(args[0], manifest, mode)
+	for _, artifact := range metadata {
+		if err := publishVerifiedSnapshot(artifact.path, artifact.contents, artifact.mode); err != nil {
+			return fmt.Errorf("publish verified release metadata %q: %w", artifact.name, err)
+		}
+	}
+	return publishVerifiedSnapshot(args[0], manifest, mode)
 }
 
 func verifyRelease(checksumPath string) error {
-	manifest, _, err := readChecksumSnapshot(checksumPath)
-	if err != nil {
-		return err
-	}
-	return verifyReleaseSnapshot(checksumPath, manifest)
+	return run([]string{checksumPath})
 }
 
-func verifyReleaseSnapshot(checksumPath string, manifest []byte) error {
+func verifyReleaseSnapshot(checksumPath string, manifest []byte, metadata *[]verifiedArtifact) error {
 	checksums, err := readChecksums(manifest)
 	if err != nil {
 		return err
@@ -116,12 +118,11 @@ func verifyReleaseSnapshot(checksumPath string, manifest []byte) error {
 	}
 	registryName := releaseName + "_manifest.json"
 	registryPath := filepath.Join(filepath.Dir(filepath.Dir(checksumPath)), "terraform-registry-manifest.json")
-	if err := verifyArtifact(registryName, registryPath, checksums); err != nil {
+	registry, err := verifyMetadataArtifact(registryName, registryPath, checksums, verifyRegistryManifest)
+	if err != nil {
 		return err
 	}
-	if err := verifyRegistryManifest(registryPath); err != nil {
-		return err
-	}
+	*metadata = append(*metadata, registry)
 
 	for name, path := range archives {
 		if err := verifyReleasePlatform(name, releaseName); err != nil {
@@ -135,12 +136,11 @@ func verifyReleaseSnapshot(checksumPath string, manifest []byte) error {
 		if err := verifyArtifact(name, path, checksums); err != nil {
 			return err
 		}
-		if err := verifyArtifact(sbomName, sbomPath, checksums); err != nil {
+		sbom, err := verifyMetadataArtifact(sbomName, sbomPath, checksums, verifySPDX)
+		if err != nil {
 			return err
 		}
-		if err := verifySPDX(sbomPath); err != nil {
-			return err
-		}
+		*metadata = append(*metadata, sbom)
 	}
 
 	for name := range checksums {
@@ -161,27 +161,27 @@ func verifyReleaseSnapshot(checksumPath string, manifest []byte) error {
 	return nil
 }
 
-func readChecksumSnapshot(path string) ([]byte, fs.FileMode, error) {
+func readArtifactSnapshot(path string) ([]byte, fs.FileMode, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return nil, 0, fmt.Errorf("read checksum manifest: %w", err)
+		return nil, 0, fmt.Errorf("read release artifact snapshot: %w", err)
 	}
 	info, statErr := file.Stat()
 	if statErr != nil {
 		_ = file.Close()
-		return nil, 0, fmt.Errorf("inspect checksum manifest: %w", statErr)
+		return nil, 0, fmt.Errorf("inspect release artifact snapshot: %w", statErr)
 	}
 	if !info.Mode().IsRegular() {
 		_ = file.Close()
-		return nil, 0, errors.New("checksum manifest is not a regular file")
+		return nil, 0, errors.New("release artifact snapshot is not a regular file")
 	}
 	manifest, readErr := io.ReadAll(file)
 	closeErr := file.Close()
 	if readErr != nil {
-		return nil, 0, fmt.Errorf("read checksum manifest: %w", readErr)
+		return nil, 0, fmt.Errorf("read release artifact snapshot: %w", readErr)
 	}
 	if closeErr != nil {
-		return nil, 0, fmt.Errorf("close checksum manifest: %w", closeErr)
+		return nil, 0, fmt.Errorf("close release artifact snapshot: %w", closeErr)
 	}
 	return manifest, info.Mode().Perm(), nil
 }
@@ -216,28 +216,28 @@ func readChecksums(manifest []byte) (map[string][]byte, error) {
 	return checksums, nil
 }
 
-func publishVerifiedChecksums(path string, manifest []byte, mode fs.FileMode) error {
-	snapshot, err := os.CreateTemp(filepath.Dir(path), ".verified-checksums-*")
+func publishVerifiedSnapshot(path string, contents []byte, mode fs.FileMode) error {
+	snapshot, err := os.CreateTemp(filepath.Dir(path), ".verified-artifact-*")
 	if err != nil {
-		return fmt.Errorf("create verified checksum snapshot: %w", err)
+		return fmt.Errorf("create verified artifact snapshot: %w", err)
 	}
 	defer func() {
 		_ = os.Remove(snapshot.Name())
 	}()
 	if err := snapshot.Chmod(mode); err != nil {
 		_ = snapshot.Close()
-		return fmt.Errorf("set verified checksum permissions: %w", err)
+		return fmt.Errorf("set verified artifact permissions: %w", err)
 	}
-	_, writeErr := snapshot.Write(manifest)
+	_, writeErr := snapshot.Write(contents)
 	closeErr := snapshot.Close()
 	if writeErr != nil {
-		return fmt.Errorf("write verified checksum snapshot: %w", writeErr)
+		return fmt.Errorf("write verified artifact snapshot: %w", writeErr)
 	}
 	if closeErr != nil {
-		return fmt.Errorf("close verified checksum snapshot: %w", closeErr)
+		return fmt.Errorf("close verified artifact snapshot: %w", closeErr)
 	}
 	if err := os.Rename(snapshot.Name(), path); err != nil {
-		return fmt.Errorf("publish verified checksum snapshot: %w", err)
+		return fmt.Errorf("publish verified artifact snapshot: %w", err)
 	}
 	return nil
 }
@@ -288,12 +288,33 @@ func verifyArtifact(name, path string, checksums map[string][]byte) error {
 	return nil
 }
 
-func verifySPDX(path string) error {
-	document, err := os.ReadFile(path)
-	if err != nil {
-		return fmt.Errorf("read SBOM %q: %w", path, err)
-	}
+type verifiedArtifact struct {
+	name     string
+	path     string
+	contents []byte
+	mode     fs.FileMode
+}
 
+func verifyMetadataArtifact(name, path string, checksums map[string][]byte, validate func(string, []byte) error) (verifiedArtifact, error) {
+	expected, exists := checksums[name]
+	if !exists {
+		return verifiedArtifact{}, fmt.Errorf("checksum manifest has no entry for %q", name)
+	}
+	contents, mode, err := readArtifactSnapshot(path)
+	if err != nil {
+		return verifiedArtifact{}, fmt.Errorf("open release artifact %q: %w", name, err)
+	}
+	digest := sha256.Sum256(contents)
+	if !bytes.Equal(digest[:], expected) {
+		return verifiedArtifact{}, fmt.Errorf("SHA-256 checksum mismatch for %q", name)
+	}
+	if err := validate(path, contents); err != nil {
+		return verifiedArtifact{}, err
+	}
+	return verifiedArtifact{name: name, path: path, contents: contents, mode: mode}, nil
+}
+
+func verifySPDX(path string, document []byte) error {
 	var spdx struct {
 		Version  string            `json:"spdxVersion"`
 		Packages []json.RawMessage `json:"packages"`
@@ -307,12 +328,7 @@ func verifySPDX(path string) error {
 	return nil
 }
 
-func verifyRegistryManifest(path string) error {
-	document, err := os.ReadFile(path)
-	if err != nil {
-		return fmt.Errorf("read Terraform Registry manifest %q: %w", path, err)
-	}
-
+func verifyRegistryManifest(path string, document []byte) error {
 	var manifest struct {
 		Version  int `json:"version"`
 		Metadata struct {

--- a/.github/actions/verify-release-sboms/verify.go
+++ b/.github/actions/verify-release-sboms/verify.go
@@ -35,8 +35,8 @@ func run(args []string) error {
 	if err != nil {
 		return err
 	}
-	var metadata []verifiedArtifact
-	if err := verifyReleaseSnapshot(args[0], manifest, &metadata); err != nil {
+	var artifacts []verifiedArtifact
+	if err := verifyReleaseSnapshot(args[0], manifest, &artifacts); err != nil {
 		return err
 	}
 	if len(args) == 1 {
@@ -52,9 +52,9 @@ func run(args []string) error {
 	if err := sign.Run(); err != nil {
 		return fmt.Errorf("sign verified checksum manifest: %w", err)
 	}
-	for _, artifact := range metadata {
+	for _, artifact := range artifacts {
 		if err := publishVerifiedSnapshot(artifact.path, artifact.contents, artifact.mode); err != nil {
-			return fmt.Errorf("publish verified release metadata %q: %w", artifact.name, err)
+			return fmt.Errorf("publish verified release artifact %q: %w", artifact.name, err)
 		}
 	}
 	return publishVerifiedSnapshot(args[0], manifest, mode)
@@ -64,7 +64,7 @@ func verifyRelease(checksumPath string) error {
 	return run([]string{checksumPath})
 }
 
-func verifyReleaseSnapshot(checksumPath string, manifest []byte, metadata *[]verifiedArtifact) error {
+func verifyReleaseSnapshot(checksumPath string, manifest []byte, artifacts *[]verifiedArtifact) error {
 	checksums, err := readChecksums(manifest)
 	if err != nil {
 		return err
@@ -122,7 +122,7 @@ func verifyReleaseSnapshot(checksumPath string, manifest []byte, metadata *[]ver
 	if err != nil {
 		return err
 	}
-	*metadata = append(*metadata, registry)
+	*artifacts = append(*artifacts, registry)
 
 	for name, path := range archives {
 		if err := verifyReleasePlatform(name, releaseName); err != nil {
@@ -133,14 +133,16 @@ func verifyReleaseSnapshot(checksumPath string, manifest []byte, metadata *[]ver
 		if !exists || sbomPath != path+".spdx.json" {
 			return fmt.Errorf("archive %q has no matching adjacent SBOM", name)
 		}
-		if err := verifyArtifact(name, path, checksums); err != nil {
+		archive, err := verifyArtifact(name, path, checksums)
+		if err != nil {
 			return err
 		}
+		*artifacts = append(*artifacts, archive)
 		sbom, err := verifyMetadataArtifact(sbomName, sbomPath, checksums, verifySPDX)
 		if err != nil {
 			return err
 		}
-		*metadata = append(*metadata, sbom)
+		*artifacts = append(*artifacts, sbom)
 	}
 
 	for name := range checksums {
@@ -262,32 +264,6 @@ func verifyReleasePlatform(name, releaseName string) error {
 	}
 }
 
-func verifyArtifact(name, path string, checksums map[string][]byte) error {
-	expected, exists := checksums[name]
-	if !exists {
-		return fmt.Errorf("checksum manifest has no entry for %q", name)
-	}
-
-	file, err := os.Open(path)
-	if err != nil {
-		return fmt.Errorf("open release artifact %q: %w", name, err)
-	}
-
-	hash := sha256.New()
-	_, hashErr := io.Copy(hash, file)
-	closeErr := file.Close()
-	if hashErr != nil {
-		return fmt.Errorf("hash release artifact %q: %w", name, hashErr)
-	}
-	if closeErr != nil {
-		return fmt.Errorf("close release artifact %q: %w", name, closeErr)
-	}
-	if !bytes.Equal(hash.Sum(nil), expected) {
-		return fmt.Errorf("SHA-256 checksum mismatch for %q", name)
-	}
-	return nil
-}
-
 type verifiedArtifact struct {
 	name     string
 	path     string
@@ -295,7 +271,7 @@ type verifiedArtifact struct {
 	mode     fs.FileMode
 }
 
-func verifyMetadataArtifact(name, path string, checksums map[string][]byte, validate func(string, []byte) error) (verifiedArtifact, error) {
+func verifyArtifact(name, path string, checksums map[string][]byte) (verifiedArtifact, error) {
 	expected, exists := checksums[name]
 	if !exists {
 		return verifiedArtifact{}, fmt.Errorf("checksum manifest has no entry for %q", name)
@@ -308,10 +284,18 @@ func verifyMetadataArtifact(name, path string, checksums map[string][]byte, vali
 	if !bytes.Equal(digest[:], expected) {
 		return verifiedArtifact{}, fmt.Errorf("SHA-256 checksum mismatch for %q", name)
 	}
-	if err := validate(path, contents); err != nil {
+	return verifiedArtifact{name: name, path: path, contents: contents, mode: mode}, nil
+}
+
+func verifyMetadataArtifact(name, path string, checksums map[string][]byte, validate func(string, []byte) error) (verifiedArtifact, error) {
+	artifact, err := verifyArtifact(name, path, checksums)
+	if err != nil {
 		return verifiedArtifact{}, err
 	}
-	return verifiedArtifact{name: name, path: path, contents: contents, mode: mode}, nil
+	if err := validate(path, artifact.contents); err != nil {
+		return verifiedArtifact{}, err
+	}
+	return artifact, nil
 }
 
 func verifySPDX(path string, document []byte) error {

--- a/.github/actions/verify-release-sboms/verify.go
+++ b/.github/actions/verify-release-sboms/verify.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"archive/zip"
 	"bufio"
 	"bytes"
 	"crypto/sha256"
+	"debug/buildinfo"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -144,7 +146,9 @@ func verifyReleaseSnapshot(checksumPath string, manifest []byte, artifacts *[]ve
 			return err
 		}
 		*artifacts = append(*artifacts, archive)
-		sbom, err := verifyMetadataArtifact(sbomName, sbomPath, checksums, verifySPDX)
+		sbom, err := verifyMetadataArtifact(sbomName, sbomPath, checksums, func(path string, document []byte) error {
+			return verifyArchiveSPDX(path, document, archive.name, archive.contents)
+		})
 		if err != nil {
 			return err
 		}
@@ -327,16 +331,119 @@ func verifyMetadataArtifact(name, path string, checksums map[string][]byte, vali
 	return artifact, nil
 }
 
-func verifySPDX(path string, document []byte) error {
-	var spdx struct {
-		Version  string            `json:"spdxVersion"`
-		Packages []json.RawMessage `json:"packages"`
-	}
+type spdxDocument struct {
+	Version       string `json:"spdxVersion"`
+	Name          string `json:"name"`
+	Relationships []struct {
+		Element string `json:"spdxElementId"`
+		Type    string `json:"relationshipType"`
+		Related string `json:"relatedSpdxElement"`
+	} `json:"relationships"`
+	Packages []struct {
+		ID       string `json:"SPDXID"`
+		Name     string `json:"name"`
+		Version  string `json:"versionInfo"`
+		Supplier string `json:"supplier"`
+		License  string `json:"licenseConcluded"`
+	} `json:"packages"`
+}
+
+func parseSPDX(path string, document []byte) (spdxDocument, error) {
+	var spdx spdxDocument
 	if err := json.Unmarshal(document, &spdx); err != nil {
-		return fmt.Errorf("parse SPDX SBOM %q: %w", path, err)
+		return spdxDocument{}, fmt.Errorf("parse SPDX SBOM %q: %w", path, err)
 	}
 	if spdx.Version == "" || len(spdx.Packages) == 0 {
-		return fmt.Errorf("SPDX SBOM %q has no version or packages", path)
+		return spdxDocument{}, fmt.Errorf("SPDX SBOM %q has no version or packages", path)
+	}
+	return spdx, nil
+}
+
+func verifyArchiveSPDX(path string, document []byte, archiveName string, archive []byte) error {
+	spdx, err := parseSPDX(path, document)
+	if err != nil {
+		return err
+	}
+	if spdx.Name != archiveName {
+		return fmt.Errorf("SPDX SBOM %q does not identify archive %q", path, archiveName)
+	}
+
+	var root string
+	for _, relationship := range spdx.Relationships {
+		if relationship.Element == "SPDXRef-DOCUMENT" && relationship.Type == "DESCRIBES" {
+			if root != "" {
+				return fmt.Errorf("SPDX SBOM %q describes more than one provider archive", path)
+			}
+			root = relationship.Related
+		}
+	}
+	if root == "" {
+		return fmt.Errorf("SPDX SBOM %q does not describe its provider archive", path)
+	}
+
+	digest := fmt.Sprintf("sha256:%x", sha256.Sum256(archive))
+	modules := make(map[string]string, len(spdx.Packages))
+	foundRoot := false
+	foundSDK := false
+	for _, entry := range spdx.Packages {
+		if entry.ID == root {
+			if entry.Name != archiveName || entry.Version != digest ||
+				entry.Supplier != "" && entry.Supplier != "NOASSERTION" {
+				return fmt.Errorf("SPDX SBOM %q has an invalid archive identity, SHA-256 digest, or supplier", path)
+			}
+			foundRoot = true
+		}
+		modules[entry.Name] = entry.Version
+		if entry.Name == "github.com/openai/openai-go/v3" && entry.License == "Apache-2.0" {
+			foundSDK = true
+		}
+	}
+	if !foundRoot {
+		return fmt.Errorf("SPDX SBOM %q has no matching provider archive package", path)
+	}
+	if !foundSDK {
+		return fmt.Errorf("SPDX SBOM %q has no Apache-2.0 OpenAI SDK package", path)
+	}
+
+	zipped, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	if err != nil {
+		return fmt.Errorf("read provider archive for SPDX SBOM %q: %w", path, err)
+	}
+	var provider *zip.File
+	for _, entry := range zipped.File {
+		if strings.HasPrefix(entry.Name, "terraform-provider-openai_v") && !strings.Contains(entry.Name, "/") {
+			if provider != nil {
+				return fmt.Errorf("provider archive for SPDX SBOM %q contains more than one provider executable", path)
+			}
+			provider = entry
+		}
+	}
+	if provider == nil {
+		return fmt.Errorf("provider archive for SPDX SBOM %q contains no provider executable", path)
+	}
+	file, err := provider.Open()
+	if err != nil {
+		return fmt.Errorf("open provider executable for SPDX SBOM %q: %w", path, err)
+	}
+	binary, readErr := io.ReadAll(file)
+	closeErr := file.Close()
+	if readErr != nil {
+		return fmt.Errorf("read provider executable for SPDX SBOM %q: %w", path, readErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close provider executable for SPDX SBOM %q: %w", path, closeErr)
+	}
+	info, err := buildinfo.Read(bytes.NewReader(binary))
+	if err != nil {
+		return fmt.Errorf("read provider module inventory for SPDX SBOM %q: %w", path, err)
+	}
+	if len(info.Deps) == 0 {
+		return fmt.Errorf("provider executable for SPDX SBOM %q has no module dependencies", path)
+	}
+	for _, module := range info.Deps {
+		if modules[module.Path] != module.Version {
+			return fmt.Errorf("SPDX SBOM %q omits provider dependency %q version %q", path, module.Path, module.Version)
+		}
 	}
 	return nil
 }
@@ -470,8 +577,7 @@ func verifyDraftArtifacts(tag, releaseName string, assets map[string]releaseAsse
 	registryName := releaseName + "_manifest.json"
 	checksumName := releaseName + "_SHA256SUMS"
 	signatureName := checksumName + ".sig"
-	archives := 0
-	sboms := 0
+	verified := make(map[string][]byte, len(assets)-2)
 	for name, asset := range assets {
 		if name == checksumName || name == signatureName {
 			continue
@@ -486,25 +592,36 @@ func verifyDraftArtifacts(tag, releaseName string, assets map[string]releaseAsse
 		if err := verifyArtifactContents(name, contents, checksums); err != nil {
 			return err
 		}
+		verified[name] = contents
+	}
+	for name := range verified {
+		if strings.HasSuffix(name, ".zip") {
+			if err := verifyReleasePlatform(name, releaseName); err != nil {
+				return err
+			}
+			if _, exists := verified[name+".spdx.json"]; !exists {
+				return fmt.Errorf("uploaded archive %q has no matching SPDX SBOM", name)
+			}
+		}
+	}
+	archives := 0
+	sboms := 0
+	for name, contents := range verified {
 		switch {
 		case name == registryName:
 			if err := verifyRegistryManifest(name, contents); err != nil {
 				return err
 			}
 		case strings.HasSuffix(name, ".zip"):
-			if err := verifyReleasePlatform(name, releaseName); err != nil {
-				return err
-			}
-			if _, exists := assets[name+".spdx.json"]; !exists {
-				return fmt.Errorf("uploaded archive %q has no matching SPDX SBOM", name)
-			}
 			archives++
 		case strings.HasSuffix(name, ".spdx.json"):
-			if err := verifySPDX(name, contents); err != nil {
-				return err
-			}
-			if _, exists := assets[strings.TrimSuffix(name, ".spdx.json")]; !exists {
+			archiveName := strings.TrimSuffix(name, ".spdx.json")
+			archive, exists := verified[archiveName]
+			if !exists {
 				return fmt.Errorf("uploaded SPDX SBOM %q has no matching archive", name)
+			}
+			if err := verifyArchiveSPDX(name, contents, archiveName, archive); err != nil {
+				return err
 			}
 			sboms++
 		default:
@@ -555,8 +672,8 @@ func verifyReleaseSignature(manifest, signature []byte, fingerprint string) erro
 	verify := exec.Command("gpg", "--batch", "--assert-signer", fingerprint, "--verify", "/dev/fd/3", "-")
 	verify.ExtraFiles = []*os.File{file}
 	verify.Stdin = bytes.NewReader(manifest)
-	if output, err := verify.CombinedOutput(); err != nil {
-		return fmt.Errorf("verify uploaded checksum signature: %w: %s", err, bytes.TrimSpace(output))
+	if err := verify.Run(); err != nil {
+		return fmt.Errorf("verify uploaded checksum signature: %w", err)
 	}
 	return nil
 }

--- a/.github/actions/verify-release-sboms/verify.go
+++ b/.github/actions/verify-release-sboms/verify.go
@@ -92,6 +92,19 @@ func verifyRelease(checksumPath string) error {
 		return fmt.Errorf("release has %d archives but %d SBOMs", len(archives), len(sboms))
 	}
 
+	releaseName, valid := strings.CutSuffix(filepath.Base(checksumPath), "_SHA256SUMS")
+	if !valid || releaseName == "" {
+		return fmt.Errorf("checksum manifest %q has no release identity", filepath.Base(checksumPath))
+	}
+	registryName := releaseName + "_manifest.json"
+	registryPath := filepath.Join(filepath.Dir(filepath.Dir(checksumPath)), "terraform-registry-manifest.json")
+	if err := verifyArtifact(registryName, registryPath, checksums); err != nil {
+		return err
+	}
+	if err := verifyRegistryManifest(registryPath); err != nil {
+		return err
+	}
+
 	for name, path := range archives {
 		sbomName := name + ".spdx.json"
 		sbomPath, exists := sboms[sbomName]
@@ -119,6 +132,9 @@ func verifyRelease(checksumPath string) error {
 			if _, exists := sboms[name]; !exists {
 				return fmt.Errorf("checksum manifest lists missing SBOM %q", name)
 			}
+		case name == registryName:
+		default:
+			return fmt.Errorf("unexpected checksum manifest entry %q", name)
 		}
 	}
 	return nil
@@ -200,6 +216,44 @@ func verifySPDX(path string) error {
 	}
 	if spdx.Version == "" || len(spdx.Packages) == 0 {
 		return fmt.Errorf("SPDX SBOM %q has no version or packages", path)
+	}
+	return nil
+}
+
+func verifyRegistryManifest(path string) error {
+	document, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read Terraform Registry manifest %q: %w", path, err)
+	}
+
+	var manifest struct {
+		Version  int `json:"version"`
+		Metadata struct {
+			ProtocolVersions []string `json:"protocol_versions"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(document, &manifest); err != nil {
+		return fmt.Errorf("parse Terraform Registry manifest %q: %w", path, err)
+	}
+	if manifest.Version != 1 {
+		return fmt.Errorf("terraform registry manifest %q has unsupported version %d", path, manifest.Version)
+	}
+	if len(manifest.Metadata.ProtocolVersions) == 0 {
+		return fmt.Errorf("terraform registry manifest %q has no protocol versions", path)
+	}
+
+	versions := make(map[string]struct{}, len(manifest.Metadata.ProtocolVersions))
+	for _, version := range manifest.Metadata.ProtocolVersions {
+		major, minor, valid := strings.Cut(version, ".")
+		if !valid || major == "" || minor == "" || strings.ContainsFunc(major+minor, func(character rune) bool {
+			return character < '0' || character > '9'
+		}) {
+			return fmt.Errorf("terraform registry manifest %q has invalid protocol version %q", path, version)
+		}
+		if _, exists := versions[version]; exists {
+			return fmt.Errorf("terraform registry manifest %q has duplicate protocol version %q", path, version)
+		}
+		versions[version] = struct{}{}
 	}
 	return nil
 }

--- a/.github/actions/verify-release-sboms/verify_test.go
+++ b/.github/actions/verify-release-sboms/verify_test.go
@@ -28,6 +28,67 @@ func TestVerifyRelease(t *testing.T) {
 			},
 		},
 		{
+			name: "supported freebsd arm release platform",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				renameFixtureArchive(t, fixture, "terraform-provider-openai_1.2.3_freebsd_arm.zip")
+			},
+		},
+		{
+			name: "supported windows arm64 release platform",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				renameFixtureArchive(t, fixture, "terraform-provider-openai_1.2.3_windows_arm64.zip")
+			},
+		},
+		{
+			name: "archive belongs to another provider",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				renameFixtureArchive(t, fixture, "terraform-provider-foreign_1.2.3_linux_amd64.zip")
+			},
+			wantErr: "does not belong to release",
+		},
+		{
+			name: "archive belongs to another release version",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				renameFixtureArchive(t, fixture, "terraform-provider-openai_9.9.9_linux_amd64.zip")
+			},
+			wantErr: "does not belong to release",
+		},
+		{
+			name: "archive has unsupported operating system",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				renameFixtureArchive(t, fixture, "terraform-provider-openai_1.2.3_plan9_amd64.zip")
+			},
+			wantErr: "unsupported release platform",
+		},
+		{
+			name: "archive has unsupported architecture",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				renameFixtureArchive(t, fixture, "terraform-provider-openai_1.2.3_linux_riscv64.zip")
+			},
+			wantErr: "unsupported release platform",
+		},
+		{
+			name: "archive uses ignored windows arm platform",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				renameFixtureArchive(t, fixture, "terraform-provider-openai_1.2.3_windows_arm.zip")
+			},
+			wantErr: "unsupported release platform",
+		},
+		{
+			name: "archive uses ignored darwin 386 platform",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				renameFixtureArchive(t, fixture, "terraform-provider-openai_1.2.3_darwin_386.zip")
+			},
+			wantErr: "unsupported release platform",
+		},
+		{
+			name: "archive has malformed release platform",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				renameFixtureArchive(t, fixture, "terraform-provider-openai_1.2.3_linux_amd64_extra.zip")
+			},
+			wantErr: "unsupported release platform",
+		},
+		{
 			name: "mismatched archive digest",
 			mutate: func(t *testing.T, fixture releaseFixture) {
 				writeFixtureFile(t, fixture.archive, []byte("tampered provider archive"))
@@ -296,6 +357,19 @@ func TestVerifyReleaseRejectsChecksumWithoutReleaseIdentity(t *testing.T) {
 	}
 }
 
+func TestVerifyReleaseRejectsForeignChecksumProject(t *testing.T) {
+	t.Parallel()
+
+	fixture := newReleaseFixture(t)
+	foreign := filepath.Join(fixture.directory, "terraform-provider-foreign_1.2.3_SHA256SUMS")
+	if err := os.Rename(fixture.manifest, foreign); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyRelease(foreign); err == nil || !strings.Contains(err.Error(), "unsupported provider release identity") {
+		t.Fatalf("checksum manifest for another Terraform provider was accepted: %v", err)
+	}
+}
+
 func TestSigningRequiresVerifiedProductionArtifacts(t *testing.T) {
 	directory := t.TempDir()
 	record := filepath.Join(directory, "gpg-invocation")
@@ -344,9 +418,103 @@ func TestSigningRequiresVerifiedProductionArtifacts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GPG was not invoked for valid production artifacts: %v", err)
 	}
-	want := "--batch\n--detach-sign\n" + valid.manifest + "\n"
+	want := "--batch\n--detach-sign\n-\n"
 	if string(got) != want {
 		t.Fatalf("GPG arguments = %q, want %q", got, want)
+	}
+}
+
+func TestSigningBindsVerifiedChecksumSnapshot(t *testing.T) {
+	directory := t.TempDir()
+	fixture := newReleaseFixture(t)
+	verified, err := os.ReadFile(fixture.manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalInfo, err := os.Stat(fixture.manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	forged := strings.Replace(string(verified), fmt.Sprintf("%x", sha256.Sum256([]byte("provider archive"))), strings.Repeat("0", 64), 1)
+	forgedPath := filepath.Join(directory, "forged-checksums")
+	signedPath := filepath.Join(directory, "signed-checksums")
+	writeFixtureFile(t, forgedPath, []byte(forged))
+
+	gpg := filepath.Join(directory, "gpg")
+	writeFixtureFile(t, gpg, []byte("#!/bin/sh\n"+
+		"mv \"$FORGED_CHECKSUMS\" \"$PUBLISHED_CHECKSUMS\"\n"+
+		"for argument in \"$@\"; do target=\"$argument\"; done\n"+
+		"if [ \"$target\" = - ]; then cat > \"$SIGNED_CHECKSUMS\"; else cat \"$target\" > \"$SIGNED_CHECKSUMS\"; fi\n"))
+	if err := os.Chmod(gpg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", directory+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FORGED_CHECKSUMS", forgedPath)
+	t.Setenv("PUBLISHED_CHECKSUMS", fixture.manifest)
+	t.Setenv("SIGNED_CHECKSUMS", signedPath)
+
+	if err := run([]string{fixture.manifest, "--sign", "--batch", "--detach-sign", fixture.manifest}); err != nil {
+		t.Fatalf("could not sign verified checksum manifest: %v", err)
+	}
+	signed, err := os.ReadFile(signedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(signed) != string(verified) {
+		t.Fatalf("GPG signed bytes other than the verified checksum snapshot: %q", signed)
+	}
+	published, err := os.ReadFile(fixture.manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(published) != string(verified) {
+		t.Fatalf("published checksum manifest differs from its verified signed snapshot: %q", published)
+	}
+	publishedInfo, err := os.Stat(fixture.manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if publishedInfo.Mode().Perm() != originalInfo.Mode().Perm() {
+		t.Fatalf("published checksum permissions = %o, want %o", publishedInfo.Mode().Perm(), originalInfo.Mode().Perm())
+	}
+	snapshots, err := filepath.Glob(filepath.Join(fixture.directory, ".verified-checksums-*"))
+	if err != nil || len(snapshots) != 0 {
+		t.Fatalf("temporary verified checksum snapshots were not cleaned up: %v, %v", snapshots, err)
+	}
+}
+
+func TestSigningRejectsUnsupportedReleaseArchives(t *testing.T) {
+	tests := []struct {
+		name    string
+		archive string
+	}{
+		{name: "another provider", archive: "terraform-provider-foreign_1.2.3_linux_amd64.zip"},
+		{name: "another release version", archive: "terraform-provider-openai_9.9.9_linux_amd64.zip"},
+		{name: "unsupported windows arm", archive: "terraform-provider-openai_1.2.3_windows_arm.zip"},
+		{name: "unsupported darwin 386", archive: "terraform-provider-openai_1.2.3_darwin_386.zip"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			directory := t.TempDir()
+			record := filepath.Join(directory, "gpg-invocation")
+			gpg := filepath.Join(directory, "gpg")
+			writeFixtureFile(t, gpg, []byte("#!/bin/sh\nprintf 'signed\\n' > \"$SIGNING_RECORD\"\n"))
+			if err := os.Chmod(gpg, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", directory+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("SIGNING_RECORD", record)
+
+			fixture := newReleaseFixture(t)
+			renameFixtureArchive(t, fixture, test.archive)
+			if err := run([]string{fixture.manifest, "--sign", "--batch", "--detach-sign", fixture.manifest}); err == nil {
+				t.Fatal("unsupported archive reached production signing")
+			}
+			if _, err := os.Stat(record); !os.IsNotExist(err) {
+				t.Fatalf("GPG signed an unsupported production archive: %v", err)
+			}
+		})
 	}
 }
 
@@ -514,6 +682,19 @@ func (fixture releaseFixture) writeChecksums(t *testing.T) {
 	fmt.Fprintf(&manifest, "%x  terraform-provider-openai_1.2.3_manifest.json\n",
 		sha256.Sum256(registry))
 	writeFixtureFile(t, fixture.manifest, []byte(manifest.String()))
+}
+
+func renameFixtureArchive(t *testing.T, fixture releaseFixture, name string) {
+	t.Helper()
+
+	replacement := filepath.Join(fixture.directory, name)
+	if err := os.Rename(fixture.archive, replacement); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(fixture.archive+".spdx.json", replacement+".spdx.json"); err != nil {
+		t.Fatal(err)
+	}
+	fixture.writeChecksums(t)
 }
 
 func removeManifestEntry(t *testing.T, fixture releaseFixture, name string) {

--- a/.github/actions/verify-release-sboms/verify_test.go
+++ b/.github/actions/verify-release-sboms/verify_test.go
@@ -670,9 +670,12 @@ func TestProductionReleaseUsesVerifiedSigner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	publish := regexp.MustCompile(`(?ms)^  goreleaser:\n.*?^    environment: publish\n.*?^          args: release --clean\n`)
+	publish := regexp.MustCompile(`(?ms)^  goreleaser:\n.*?^    environment: publish\n.*?^          args: release --clean --draft\n.*?^      - name: Verify and publish release draft\n`)
 	if !publish.Match(workflow) {
-		t.Fatal("approved production publishing job does not execute the verified GoReleaser release")
+		t.Fatal("approved production publishing job does not verify the private GoReleaser draft before publication")
+	}
+	if !strings.Contains(string(workflow), `release-verifier --publish "$GITHUB_REF_NAME" "$GPG_FINGERPRINT"`) {
+		t.Fatal("production publishing job does not require the trusted release-wide publication verifier")
 	}
 }
 

--- a/.github/actions/verify-release-sboms/verify_test.go
+++ b/.github/actions/verify-release-sboms/verify_test.go
@@ -21,6 +21,13 @@ func TestVerifyRelease(t *testing.T) {
 	}{
 		{name: "valid archives, SPDX documents, and checksums"},
 		{
+			name: "multiple supported Terraform Registry protocol versions",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				writeFixtureFile(t, fixture.registry, []byte(`{"version":1,"metadata":{"protocol_versions":["5.0","6.0"]}}`))
+				fixture.writeChecksums(t)
+			},
+		},
+		{
 			name: "mismatched archive digest",
 			mutate: func(t *testing.T, fixture releaseFixture) {
 				writeFixtureFile(t, fixture.archive, []byte("tampered provider archive"))
@@ -33,6 +40,108 @@ func TestVerifyRelease(t *testing.T) {
 				writeFixtureFile(t, fixture.archive+".spdx.json", []byte(`{"spdxVersion":"SPDX-2.3","packages":[{"name":"tampered"}]}`))
 			},
 			wantErr: "SHA-256 checksum mismatch",
+		},
+		{
+			name: "tampered Terraform Registry manifest source",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				writeFixtureFile(t, fixture.registry, []byte(`{"version":1,"metadata":{"protocol_versions":["5.0"]}}`))
+			},
+			wantErr: "SHA-256 checksum mismatch",
+		},
+		{
+			name: "mismatched Terraform Registry manifest digest",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				name := "terraform-provider-openai_1.2.3_manifest.json"
+				removeManifestEntry(t, fixture, name)
+				appendManifestEntry(t, fixture, name, []byte("tampered registry manifest"))
+			},
+			wantErr: "SHA-256 checksum mismatch",
+		},
+		{
+			name: "missing Terraform Registry manifest entry",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				removeManifestEntry(t, fixture, "terraform-provider-openai_1.2.3_manifest.json")
+			},
+			wantErr: "checksum manifest has no entry",
+		},
+		{
+			name: "wrong Terraform Registry manifest release identity",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				removeManifestEntry(t, fixture, "terraform-provider-openai_1.2.3_manifest.json")
+				appendManifestEntry(t, fixture, "terraform-provider-openai_9.9.9_manifest.json", []byte("different release"))
+			},
+			wantErr: "checksum manifest has no entry",
+		},
+		{
+			name: "extra Terraform Registry manifest entry",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				appendManifestEntry(t, fixture, "terraform-provider-openai_9.9.9_manifest.json", []byte("different release"))
+			},
+			wantErr: "unexpected checksum manifest entry",
+		},
+		{
+			name: "missing Terraform Registry manifest source",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				if err := os.Remove(fixture.registry); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErr: "open release artifact",
+		},
+		{
+			name: "malformed Terraform Registry manifest JSON",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				writeFixtureFile(t, fixture.registry, []byte(`{"version":`))
+				fixture.writeChecksums(t)
+			},
+			wantErr: "parse Terraform Registry manifest",
+		},
+		{
+			name: "unsupported Terraform Registry manifest version",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				writeFixtureFile(t, fixture.registry, []byte(`{"version":2,"metadata":{"protocol_versions":["6.0"]}}`))
+				fixture.writeChecksums(t)
+			},
+			wantErr: "unsupported version",
+		},
+		{
+			name: "missing Terraform Registry protocol versions",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				writeFixtureFile(t, fixture.registry, []byte(`{"version":1,"metadata":{"protocol_versions":[]}}`))
+				fixture.writeChecksums(t)
+			},
+			wantErr: "has no protocol versions",
+		},
+		{
+			name: "empty Terraform Registry protocol version",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				writeFixtureFile(t, fixture.registry, []byte(`{"version":1,"metadata":{"protocol_versions":[""]}}`))
+				fixture.writeChecksums(t)
+			},
+			wantErr: "invalid protocol version",
+		},
+		{
+			name: "malformed Terraform Registry protocol version",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				writeFixtureFile(t, fixture.registry, []byte(`{"version":1,"metadata":{"protocol_versions":["6.x"]}}`))
+				fixture.writeChecksums(t)
+			},
+			wantErr: "invalid protocol version",
+		},
+		{
+			name: "duplicate Terraform Registry protocol version",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				writeFixtureFile(t, fixture.registry, []byte(`{"version":1,"metadata":{"protocol_versions":["6.0","6.0"]}}`))
+				fixture.writeChecksums(t)
+			},
+			wantErr: "duplicate protocol version",
+		},
+		{
+			name: "unexpected checksum manifest entry",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				appendManifestEntry(t, fixture, "unexpected.json", []byte("unverified metadata"))
+			},
+			wantErr: "unexpected checksum manifest entry",
 		},
 		{
 			name: "missing archive manifest entry",
@@ -174,6 +283,19 @@ func TestVerifyRelease(t *testing.T) {
 	}
 }
 
+func TestVerifyReleaseRejectsChecksumWithoutReleaseIdentity(t *testing.T) {
+	t.Parallel()
+
+	fixture := newReleaseFixture(t)
+	unexpected := filepath.Join(fixture.directory, "checksums.txt")
+	if err := os.Rename(fixture.manifest, unexpected); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyRelease(unexpected); err == nil || !strings.Contains(err.Error(), "has no release identity") {
+		t.Fatalf("checksum manifest without a release identity was accepted: %v", err)
+	}
+}
+
 func TestSigningRequiresVerifiedProductionArtifacts(t *testing.T) {
 	directory := t.TempDir()
 	record := filepath.Join(directory, "gpg-invocation")
@@ -202,6 +324,16 @@ func TestSigningRequiresVerifiedProductionArtifacts(t *testing.T) {
 	}
 	if _, err := os.Stat(record); !os.IsNotExist(err) {
 		t.Fatalf("GPG was invoked for unverified production artifacts: %v", err)
+	}
+
+	invalidRegistry := newReleaseFixture(t)
+	writeFixtureFile(t, invalidRegistry.registry, []byte(`{"version":1,"metadata":{"protocol_versions":["5.0"]}}`))
+	if err := run([]string{invalidRegistry.manifest, "--sign", "--batch", "--detach-sign", invalidRegistry.manifest}); err == nil ||
+		!strings.Contains(err.Error(), "SHA-256 checksum mismatch") {
+		t.Fatalf("tampered Terraform Registry metadata reached signing: %v", err)
+	}
+	if _, err := os.Stat(record); !os.IsNotExist(err) {
+		t.Fatalf("GPG was invoked for unverified Terraform Registry metadata: %v", err)
 	}
 
 	valid := newReleaseFixture(t)
@@ -328,18 +460,25 @@ type releaseFixture struct {
 	directory string
 	archive   string
 	manifest  string
+	registry  string
 }
 
 func newReleaseFixture(t *testing.T) releaseFixture {
 	t.Helper()
 
-	directory := t.TempDir()
+	root := t.TempDir()
+	directory := filepath.Join(root, "dist")
+	if err := os.Mkdir(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	archive := filepath.Join(directory, "terraform-provider-openai_1.2.3_linux_amd64.zip")
 	fixture := releaseFixture{
 		directory: directory,
 		archive:   archive,
 		manifest:  filepath.Join(directory, "terraform-provider-openai_1.2.3_SHA256SUMS"),
+		registry:  filepath.Join(root, "terraform-registry-manifest.json"),
 	}
+	writeFixtureFile(t, fixture.registry, []byte(`{"version":1,"metadata":{"protocol_versions":["6.0"]}}`))
 	writeFixtureFile(t, archive, []byte("provider archive"))
 	writeFixtureFile(t, archive+".spdx.json",
 		[]byte(`{"spdxVersion":"SPDX-2.3","packages":[{"name":"terraform-provider-openai"}]}`))
@@ -366,10 +505,14 @@ func (fixture releaseFixture) writeChecksums(t *testing.T) {
 		fmt.Fprintf(&manifest, "%x  %s\n", sha256.Sum256(contents), entry.Name())
 	}
 
-	// GoReleaser signs the renamed Terraform Registry metadata even when that
-	// metadata is not present as a file beside the generated release artifacts.
+	registry, err := os.ReadFile(fixture.registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// GoReleaser signs the renamed Terraform Registry metadata while its source
+	// remains in the repository root instead of beside the release artifacts.
 	fmt.Fprintf(&manifest, "%x  terraform-provider-openai_1.2.3_manifest.json\n",
-		sha256.Sum256([]byte(`{"version":1}`)))
+		sha256.Sum256(registry))
 	writeFixtureFile(t, fixture.manifest, []byte(manifest.String()))
 }
 

--- a/.github/actions/verify-release-sboms/verify_test.go
+++ b/.github/actions/verify-release-sboms/verify_test.go
@@ -443,7 +443,11 @@ func TestSigningBindsVerifiedChecksumSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	forged := strings.Replace(string(verified), fmt.Sprintf("%x", sha256.Sum256([]byte("provider archive"))), strings.Repeat("0", 64), 1)
+	archive, err := os.ReadFile(fixture.archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	forged := strings.Replace(string(verified), fmt.Sprintf("%x", sha256.Sum256(archive)), strings.Repeat("0", 64), 1)
 	forgedPath := filepath.Join(directory, "forged-checksums")
 	signedPath := filepath.Join(directory, "signed-checksums")
 	writeFixtureFile(t, forgedPath, []byte(forged))
@@ -589,8 +593,11 @@ func TestMetadataValidationUsesItsHashedSnapshot(t *testing.T) {
 			},
 			malformed: `{"spdxVersion":"SPDX-2.3","packages":[]}`,
 			valid:     `{"spdxVersion":"SPDX-2.3","packages":[{"name":"provider"}]}`,
-			validate:  verifySPDX,
-			wantErr:   "has no version or packages",
+			validate: func(path string, document []byte) error {
+				_, err := parseSPDX(path, document)
+				return err
+			},
+			wantErr: "has no version or packages",
 		},
 	}
 
@@ -801,9 +808,7 @@ func newReleaseFixture(t *testing.T) releaseFixture {
 	writeFixtureFile(t, fixture.registry, []byte(`{"version":1,"metadata":{"protocol_versions":["6.0"]}}`))
 	for _, platform := range releasePlatforms {
 		path := filepath.Join(directory, "terraform-provider-openai_1.2.3_"+platform+".zip")
-		writeFixtureFile(t, path, []byte("provider archive"))
-		writeFixtureFile(t, path+".spdx.json",
-			[]byte(`{"spdxVersion":"SPDX-2.3","packages":[{"name":"terraform-provider-openai"}]}`))
+		writeReleaseFixtureArchive(t, path)
 	}
 	fixture.writeChecksums(t)
 	return fixture

--- a/.github/actions/verify-release-sboms/verify_test.go
+++ b/.github/actions/verify-release-sboms/verify_test.go
@@ -483,12 +483,17 @@ func TestSigningBindsVerifiedChecksumSnapshot(t *testing.T) {
 	}
 }
 
-func TestSigningRestoresValidatedMetadataSnapshots(t *testing.T) {
+func TestSigningRestoresValidatedArtifactSnapshots(t *testing.T) {
 	tests := []struct {
 		name      string
 		artifact  func(releaseFixture) string
 		malformed string
 	}{
+		{
+			name:      "provider ZIP archive",
+			artifact:  func(fixture releaseFixture) string { return fixture.archive },
+			malformed: "replaced provider binary archive",
+		},
 		{
 			name:      "Terraform Registry manifest",
 			artifact:  func(fixture releaseFixture) string { return fixture.registry },
@@ -514,37 +519,37 @@ func TestSigningRestoresValidatedMetadataSnapshots(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			malformed := filepath.Join(directory, "malformed-metadata")
+			malformed := filepath.Join(directory, "malformed-artifact")
 			writeFixtureFile(t, malformed, []byte(test.malformed))
 			record := filepath.Join(directory, "gpg-invocation")
 			gpg := filepath.Join(directory, "gpg")
 			writeFixtureFile(t, gpg, []byte("#!/bin/sh\n"+
-				"mv \"$MALFORMED_METADATA\" \"$PUBLISHED_METADATA\"\n"+
+				"mv \"$MALFORMED_ARTIFACT\" \"$PUBLISHED_ARTIFACT\"\n"+
 				"cat > /dev/null\nprintf 'signed\\n' > \"$SIGNING_RECORD\"\n"))
 			if err := os.Chmod(gpg, 0o755); err != nil {
 				t.Fatal(err)
 			}
 			t.Setenv("PATH", directory+string(os.PathListSeparator)+os.Getenv("PATH"))
-			t.Setenv("MALFORMED_METADATA", malformed)
-			t.Setenv("PUBLISHED_METADATA", path)
+			t.Setenv("MALFORMED_ARTIFACT", malformed)
+			t.Setenv("PUBLISHED_ARTIFACT", path)
 			t.Setenv("SIGNING_RECORD", record)
 
 			if err := run([]string{fixture.manifest, "--sign", "--batch", "--detach-sign", fixture.manifest}); err != nil {
-				t.Fatalf("could not sign verified release metadata: %v", err)
+				t.Fatalf("could not sign verified release artifacts: %v", err)
 			}
 			if _, err := os.Stat(record); err != nil {
-				t.Fatalf("verified release metadata did not reach GPG: %v", err)
+				t.Fatalf("verified release artifacts did not reach GPG: %v", err)
 			}
 			published, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if string(published) != string(verified) {
-				t.Fatalf("published metadata differs from its verified structural/digest snapshot: %q", published)
+				t.Fatalf("published artifact differs from its verified digest snapshot: %q", published)
 			}
 			publishedInfo, err := os.Stat(path)
 			if err != nil || publishedInfo.Mode().Perm() != originalInfo.Mode().Perm() {
-				t.Fatalf("published metadata permissions differ from their verified snapshot: %v", err)
+				t.Fatalf("published artifact permissions differ from their verified snapshot: %v", err)
 			}
 		})
 	}

--- a/.github/actions/verify-release-sboms/verify_test.go
+++ b/.github/actions/verify-release-sboms/verify_test.go
@@ -30,13 +30,17 @@ func TestVerifyRelease(t *testing.T) {
 		{
 			name: "supported freebsd arm release platform",
 			mutate: func(t *testing.T, fixture releaseFixture) {
-				renameFixtureArchive(t, fixture, "terraform-provider-openai_1.2.3_freebsd_arm.zip")
+				if _, err := os.Stat(filepath.Join(fixture.directory, "terraform-provider-openai_1.2.3_freebsd_arm.zip")); err != nil {
+					t.Fatal(err)
+				}
 			},
 		},
 		{
 			name: "supported windows arm64 release platform",
 			mutate: func(t *testing.T, fixture releaseFixture) {
-				renameFixtureArchive(t, fixture, "terraform-provider-openai_1.2.3_windows_arm64.zip")
+				if _, err := os.Stat(filepath.Join(fixture.directory, "terraform-provider-openai_1.2.3_windows_arm64.zip")); err != nil {
+					t.Fatal(err)
+				}
 			},
 		},
 		{
@@ -312,7 +316,11 @@ func TestVerifyRelease(t *testing.T) {
 		{
 			name: "no archives",
 			mutate: func(t *testing.T, fixture releaseFixture) {
-				for _, path := range []string{fixture.archive, fixture.archive + ".spdx.json"} {
+				paths, err := filepath.Glob(filepath.Join(fixture.directory, "*.zip*"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, path := range paths {
 					if err := os.Remove(path); err != nil {
 						t.Fatal(err)
 					}
@@ -785,9 +793,12 @@ func newReleaseFixture(t *testing.T) releaseFixture {
 		registry:  filepath.Join(root, "terraform-registry-manifest.json"),
 	}
 	writeFixtureFile(t, fixture.registry, []byte(`{"version":1,"metadata":{"protocol_versions":["6.0"]}}`))
-	writeFixtureFile(t, archive, []byte("provider archive"))
-	writeFixtureFile(t, archive+".spdx.json",
-		[]byte(`{"spdxVersion":"SPDX-2.3","packages":[{"name":"terraform-provider-openai"}]}`))
+	for _, platform := range releasePlatforms {
+		path := filepath.Join(directory, "terraform-provider-openai_1.2.3_"+platform+".zip")
+		writeFixtureFile(t, path, []byte("provider archive"))
+		writeFixtureFile(t, path+".spdx.json",
+			[]byte(`{"spdxVersion":"SPDX-2.3","packages":[{"name":"terraform-provider-openai"}]}`))
+	}
 	fixture.writeChecksums(t)
 	return fixture
 }

--- a/.github/actions/verify-release-sboms/verify_test.go
+++ b/.github/actions/verify-release-sboms/verify_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -225,9 +226,9 @@ func TestProductionReleaseUsesVerifiedSigner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	signer := regexp.MustCompile(`(?m)^signs:\n  - artifacts: checksum\n    cmd: go\n    args:\n      - run\n      - \.github/actions/verify-release-sboms/verify\.go\n      - "\$\{artifact\}"\n      - --sign\n`)
+	signer := regexp.MustCompile(`(?m)^signs:\n  - artifacts: checksum\n    cmd: release-verifier\n    args:\n      - "\$\{artifact\}"\n      - --sign\n`)
 	if !signer.Match(configuration) {
-		t.Fatal("GoReleaser production checksum signing does not verify its exact artifact manifest")
+		t.Fatal("GoReleaser production checksum signing does not use the trusted prebuilt verifier")
 	}
 
 	workflow, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "release.yml"))
@@ -237,6 +238,89 @@ func TestProductionReleaseUsesVerifiedSigner(t *testing.T) {
 	publish := regexp.MustCompile(`(?ms)^  goreleaser:\n.*?^    environment: publish\n.*?^          args: release --clean\n`)
 	if !publish.Match(workflow) {
 		t.Fatal("approved production publishing job does not execute the verified GoReleaser release")
+	}
+}
+
+func TestProductionSigningDoesNotRestoreSharedGoCache(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := os.ReadFile(filepath.Join("..", "..", "..", ".github", "workflows", "release.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	publishStart := strings.Index(string(workflow), "\n  goreleaser:\n")
+	if publishStart < 0 {
+		t.Fatal("production publishing job was not found")
+	}
+	publish := string(workflow[publishStart:])
+
+	setup := regexp.MustCompile(`(?m)^      - uses: actions/setup-go@[^\n]+\n        with:\n          go-version-file: go\.mod\n          cache: false\n`)
+	setupLocation := setup.FindStringIndex(publish)
+	if setupLocation == nil {
+		t.Fatal("production publishing job restores a shared Go build cache")
+	}
+
+	build := strings.Index(publish, "      - name: Build trusted release verifier\n")
+	secrets := strings.Index(publish, "      - name: Check publish environment secrets\n")
+	importKey := strings.Index(publish, "      - name: Import GPG key\n")
+	release := strings.Index(publish, "      - name: Run GoReleaser\n")
+	if build < 0 || secrets < 0 || importKey < 0 || release < 0 || setupLocation[0] >= build || build >= secrets || secrets >= importKey || importKey >= release {
+		t.Fatal("trusted release verifier is not built before signing secrets are exposed")
+	}
+	trustedBuild := publish[build:secrets]
+
+	for _, command := range []string{
+		`GOCACHE="$(mktemp -d "$RUNNER_TEMP/release-go-build-cache.XXXXXX")"`,
+		`export GOCACHE`,
+		`echo "GOCACHE=$GOCACHE" >> "$GITHUB_ENV"`,
+		`go build -trimpath -o "$RUNNER_TEMP/release-verifier" .github/actions/verify-release-sboms/verify.go`,
+		`echo "$RUNNER_TEMP" >> "$GITHUB_PATH"`,
+	} {
+		if !strings.Contains(trustedBuild, command) {
+			t.Errorf("production publishing job does not enforce isolated signing prerequisite %q", command)
+		}
+	}
+}
+
+func TestPrebuiltSignerIgnoresHostileGoBuildCache(t *testing.T) {
+	t.Parallel()
+
+	directory := t.TempDir()
+	verifier := filepath.Join(directory, "release-verifier")
+	build := exec.Command("go", "build", "-trimpath", "-o", verifier, "verify.go")
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build trusted release verifier before signing: %v\n%s", err, output)
+	}
+
+	signingRecord := filepath.Join(directory, "gpg-invocation")
+	goRecord := filepath.Join(directory, "hostile-go-invocation")
+	for name, source := range map[string]string{
+		"gpg": "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$SIGNING_RECORD\"\n",
+		"go":  "#!/bin/sh\nprintf 'hostile Go toolchain executed\\n' > \"$GO_INVOCATION_RECORD\"\nexit 90\n",
+	} {
+		path := filepath.Join(directory, name)
+		writeFixtureFile(t, path, []byte(source))
+		if err := os.Chmod(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fixture := newReleaseFixture(t)
+	sign := exec.Command(verifier, fixture.manifest, "--sign", "--batch", "--detach-sign", fixture.manifest)
+	sign.Env = append(os.Environ(),
+		"PATH="+directory+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GOCACHE="+filepath.Join(directory, "hostile-shared-cache"),
+		"SIGNING_RECORD="+signingRecord,
+		"GO_INVOCATION_RECORD="+goRecord,
+	)
+	if output, err := sign.CombinedOutput(); err != nil {
+		t.Fatalf("trusted verifier rejected valid production artifacts: %v\n%s", err, output)
+	}
+	if _, err := os.Stat(goRecord); !os.IsNotExist(err) {
+		t.Fatalf("production signer executed the hostile Go toolchain: %v", err)
+	}
+	if _, err := os.Stat(signingRecord); err != nil {
+		t.Fatalf("trusted verifier did not sign valid production artifacts: %v", err)
 	}
 }
 

--- a/.github/actions/verify-release-sboms/verify_test.go
+++ b/.github/actions/verify-release-sboms/verify_test.go
@@ -1,0 +1,328 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestVerifyRelease(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(*testing.T, releaseFixture)
+		wantErr string
+	}{
+		{name: "valid archives, SPDX documents, and checksums"},
+		{
+			name: "mismatched archive digest",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				writeFixtureFile(t, fixture.archive, []byte("tampered provider archive"))
+			},
+			wantErr: "SHA-256 checksum mismatch",
+		},
+		{
+			name: "mismatched SBOM digest",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				writeFixtureFile(t, fixture.archive+".spdx.json", []byte(`{"spdxVersion":"SPDX-2.3","packages":[{"name":"tampered"}]}`))
+			},
+			wantErr: "SHA-256 checksum mismatch",
+		},
+		{
+			name: "missing archive manifest entry",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				removeManifestEntry(t, fixture, filepath.Base(fixture.archive))
+			},
+			wantErr: "checksum manifest has no entry",
+		},
+		{
+			name: "missing SBOM manifest entry",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				removeManifestEntry(t, fixture, filepath.Base(fixture.archive)+".spdx.json")
+			},
+			wantErr: "checksum manifest has no entry",
+		},
+		{
+			name: "malformed SPDX JSON",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				writeFixtureFile(t, fixture.archive+".spdx.json", []byte(`{"spdxVersion":`))
+				fixture.writeChecksums(t)
+			},
+			wantErr: "parse SPDX SBOM",
+		},
+		{
+			name: "missing SPDX version",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				writeFixtureFile(t, fixture.archive+".spdx.json", []byte(`{"packages":[{"name":"provider"}]}`))
+				fixture.writeChecksums(t)
+			},
+			wantErr: "has no version or packages",
+		},
+		{
+			name: "empty SPDX packages",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				writeFixtureFile(t, fixture.archive+".spdx.json", []byte(`{"spdxVersion":"SPDX-2.3","packages":[]}`))
+				fixture.writeChecksums(t)
+			},
+			wantErr: "has no version or packages",
+		},
+		{
+			name: "missing SBOM",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				if err := os.Remove(fixture.archive + ".spdx.json"); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErr: "archives but",
+		},
+		{
+			name: "extra SBOM",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				writeFixtureFile(t, filepath.Join(fixture.directory, "unexpected.zip.spdx.json"),
+					[]byte(`{"spdxVersion":"SPDX-2.3","packages":[{"name":"unexpected"}]}`))
+				fixture.writeChecksums(t)
+			},
+			wantErr: "archives but",
+		},
+		{
+			name: "unpaired SBOM",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				if err := os.Rename(fixture.archive+".spdx.json", filepath.Join(fixture.directory, "unexpected.zip.spdx.json")); err != nil {
+					t.Fatal(err)
+				}
+				fixture.writeChecksums(t)
+			},
+			wantErr: "no matching adjacent SBOM",
+		},
+		{
+			name: "manifest lists missing archive",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				appendManifestEntry(t, fixture, "missing.zip", []byte("missing archive"))
+			},
+			wantErr: "checksum manifest lists missing archive",
+		},
+		{
+			name: "manifest lists missing SBOM",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				appendManifestEntry(t, fixture, "missing.zip.spdx.json", []byte("missing SBOM"))
+			},
+			wantErr: "checksum manifest lists missing SBOM",
+		},
+		{
+			name: "duplicate checksum entry",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				contents, err := os.ReadFile(fixture.archive)
+				if err != nil {
+					t.Fatal(err)
+				}
+				appendManifestEntry(t, fixture, filepath.Base(fixture.archive), contents)
+			},
+			wantErr: "duplicate checksum manifest entry",
+		},
+		{
+			name: "malformed checksum digest",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				writeFixtureFile(t, fixture.manifest, []byte("not-a-sha256-digest  provider.zip\n"))
+			},
+			wantErr: "malformed SHA-256 checksum manifest entry",
+		},
+		{
+			name: "manifest path traversal",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				appendManifestEntry(t, fixture, "../provider.zip", []byte("outside archive"))
+			},
+			wantErr: "not an artifact filename",
+		},
+		{
+			name: "no archives",
+			mutate: func(t *testing.T, fixture releaseFixture) {
+				for _, path := range []string{fixture.archive, fixture.archive + ".spdx.json"} {
+					if err := os.Remove(path); err != nil {
+						t.Fatal(err)
+					}
+				}
+			},
+			wantErr: "release contains no provider archives",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := newReleaseFixture(t)
+			if test.mutate != nil {
+				test.mutate(t, fixture)
+			}
+			err := verifyRelease(fixture.manifest)
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("valid release was rejected: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("verifyRelease() error = %v, want error containing %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestSigningRequiresVerifiedProductionArtifacts(t *testing.T) {
+	directory := t.TempDir()
+	record := filepath.Join(directory, "gpg-invocation")
+	writeFixtureFile(t, filepath.Join(directory, "gpg"),
+		[]byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$SIGNING_RECORD\"\n"))
+	if err := os.Chmod(filepath.Join(directory, "gpg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", directory+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("SIGNING_RECORD", record)
+
+	verified := newReleaseFixture(t)
+	unverified := newReleaseFixture(t)
+	if err := run([]string{verified.manifest, "--sign", "--batch", "--detach-sign", unverified.manifest}); err == nil ||
+		!strings.Contains(err.Error(), "signing target does not match verified checksum manifest") {
+		t.Fatalf("signing target was not bound to the verified manifest: %v", err)
+	}
+	if _, err := os.Stat(record); !os.IsNotExist(err) {
+		t.Fatalf("GPG was invoked for a different unverified checksum manifest: %v", err)
+	}
+
+	invalid := newReleaseFixture(t)
+	writeFixtureFile(t, invalid.archive, []byte("tampered production archive"))
+	if err := run([]string{invalid.manifest, "--sign", "--batch", "--detach-sign", invalid.manifest}); err == nil || !strings.Contains(err.Error(), "SHA-256 checksum mismatch") {
+		t.Fatalf("tampered production artifacts reached signing: %v", err)
+	}
+	if _, err := os.Stat(record); !os.IsNotExist(err) {
+		t.Fatalf("GPG was invoked for unverified production artifacts: %v", err)
+	}
+
+	valid := newReleaseFixture(t)
+	if err := run([]string{valid.manifest, "--sign", "--batch", "--detach-sign", valid.manifest}); err != nil {
+		t.Fatalf("valid production artifacts could not be signed: %v", err)
+	}
+	got, err := os.ReadFile(record)
+	if err != nil {
+		t.Fatalf("GPG was not invoked for valid production artifacts: %v", err)
+	}
+	want := "--batch\n--detach-sign\n" + valid.manifest + "\n"
+	if string(got) != want {
+		t.Fatalf("GPG arguments = %q, want %q", got, want)
+	}
+}
+
+func TestProductionReleaseUsesVerifiedSigner(t *testing.T) {
+	t.Parallel()
+
+	repository := filepath.Join("..", "..", "..")
+	configuration, err := os.ReadFile(filepath.Join(repository, ".goreleaser.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := regexp.MustCompile(`(?m)^signs:\n  - artifacts: checksum\n    cmd: go\n    args:\n      - run\n      - \.github/actions/verify-release-sboms/verify\.go\n      - "\$\{artifact\}"\n      - --sign\n`)
+	if !signer.Match(configuration) {
+		t.Fatal("GoReleaser production checksum signing does not verify its exact artifact manifest")
+	}
+
+	workflow, err := os.ReadFile(filepath.Join(repository, ".github", "workflows", "release.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	publish := regexp.MustCompile(`(?ms)^  goreleaser:\n.*?^    environment: publish\n.*?^          args: release --clean\n`)
+	if !publish.Match(workflow) {
+		t.Fatal("approved production publishing job does not execute the verified GoReleaser release")
+	}
+}
+
+type releaseFixture struct {
+	directory string
+	archive   string
+	manifest  string
+}
+
+func newReleaseFixture(t *testing.T) releaseFixture {
+	t.Helper()
+
+	directory := t.TempDir()
+	archive := filepath.Join(directory, "terraform-provider-openai_1.2.3_linux_amd64.zip")
+	fixture := releaseFixture{
+		directory: directory,
+		archive:   archive,
+		manifest:  filepath.Join(directory, "terraform-provider-openai_1.2.3_SHA256SUMS"),
+	}
+	writeFixtureFile(t, archive, []byte("provider archive"))
+	writeFixtureFile(t, archive+".spdx.json",
+		[]byte(`{"spdxVersion":"SPDX-2.3","packages":[{"name":"terraform-provider-openai"}]}`))
+	fixture.writeChecksums(t)
+	return fixture
+}
+
+func (fixture releaseFixture) writeChecksums(t *testing.T) {
+	t.Helper()
+
+	entries, err := os.ReadDir(fixture.directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest strings.Builder
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry.Name(), ".zip") && !strings.HasSuffix(entry.Name(), ".spdx.json") {
+			continue
+		}
+		contents, err := os.ReadFile(filepath.Join(fixture.directory, entry.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		fmt.Fprintf(&manifest, "%x  %s\n", sha256.Sum256(contents), entry.Name())
+	}
+
+	// GoReleaser signs the renamed Terraform Registry metadata even when that
+	// metadata is not present as a file beside the generated release artifacts.
+	fmt.Fprintf(&manifest, "%x  terraform-provider-openai_1.2.3_manifest.json\n",
+		sha256.Sum256([]byte(`{"version":1}`)))
+	writeFixtureFile(t, fixture.manifest, []byte(manifest.String()))
+}
+
+func removeManifestEntry(t *testing.T, fixture releaseFixture, name string) {
+	t.Helper()
+
+	contents, err := os.ReadFile(fixture.manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var retained []string
+	for _, line := range strings.Split(strings.TrimSuffix(string(contents), "\n"), "\n") {
+		if !strings.HasSuffix(line, "  "+name) {
+			retained = append(retained, line)
+		}
+	}
+	writeFixtureFile(t, fixture.manifest, []byte(strings.Join(retained, "\n")+"\n"))
+}
+
+func appendManifestEntry(t *testing.T, fixture releaseFixture, name string, contents []byte) {
+	t.Helper()
+
+	manifest, err := os.OpenFile(fixture.manifest, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprintf(manifest, "%x  %s\n", sha256.Sum256(contents), name); err != nil {
+		t.Fatal(err)
+	}
+	if err := manifest.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeFixtureFile(t *testing.T, path string, contents []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, contents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/.github/actions/verify-release-sboms/verify_test.go
+++ b/.github/actions/verify-release-sboms/verify_test.go
@@ -477,9 +477,139 @@ func TestSigningBindsVerifiedChecksumSnapshot(t *testing.T) {
 	if publishedInfo.Mode().Perm() != originalInfo.Mode().Perm() {
 		t.Fatalf("published checksum permissions = %o, want %o", publishedInfo.Mode().Perm(), originalInfo.Mode().Perm())
 	}
-	snapshots, err := filepath.Glob(filepath.Join(fixture.directory, ".verified-checksums-*"))
+	snapshots, err := filepath.Glob(filepath.Join(fixture.directory, ".verified-*"))
 	if err != nil || len(snapshots) != 0 {
 		t.Fatalf("temporary verified checksum snapshots were not cleaned up: %v, %v", snapshots, err)
+	}
+}
+
+func TestSigningRestoresValidatedMetadataSnapshots(t *testing.T) {
+	tests := []struct {
+		name      string
+		artifact  func(releaseFixture) string
+		malformed string
+	}{
+		{
+			name:      "Terraform Registry manifest",
+			artifact:  func(fixture releaseFixture) string { return fixture.registry },
+			malformed: `{"version":1,"metadata":{"protocol_versions":["not-a-protocol"]}}`,
+		},
+		{
+			name:      "SPDX SBOM",
+			artifact:  func(fixture releaseFixture) string { return fixture.archive + ".spdx.json" },
+			malformed: `{"spdxVersion":"SPDX-2.3","packages":[]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			directory := t.TempDir()
+			fixture := newReleaseFixture(t)
+			path := test.artifact(fixture)
+			verified, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			originalInfo, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			malformed := filepath.Join(directory, "malformed-metadata")
+			writeFixtureFile(t, malformed, []byte(test.malformed))
+			record := filepath.Join(directory, "gpg-invocation")
+			gpg := filepath.Join(directory, "gpg")
+			writeFixtureFile(t, gpg, []byte("#!/bin/sh\n"+
+				"mv \"$MALFORMED_METADATA\" \"$PUBLISHED_METADATA\"\n"+
+				"cat > /dev/null\nprintf 'signed\\n' > \"$SIGNING_RECORD\"\n"))
+			if err := os.Chmod(gpg, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", directory+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("MALFORMED_METADATA", malformed)
+			t.Setenv("PUBLISHED_METADATA", path)
+			t.Setenv("SIGNING_RECORD", record)
+
+			if err := run([]string{fixture.manifest, "--sign", "--batch", "--detach-sign", fixture.manifest}); err != nil {
+				t.Fatalf("could not sign verified release metadata: %v", err)
+			}
+			if _, err := os.Stat(record); err != nil {
+				t.Fatalf("verified release metadata did not reach GPG: %v", err)
+			}
+			published, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(published) != string(verified) {
+				t.Fatalf("published metadata differs from its verified structural/digest snapshot: %q", published)
+			}
+			publishedInfo, err := os.Stat(path)
+			if err != nil || publishedInfo.Mode().Perm() != originalInfo.Mode().Perm() {
+				t.Fatalf("published metadata permissions differ from their verified snapshot: %v", err)
+			}
+		})
+	}
+}
+
+func TestMetadataValidationUsesItsHashedSnapshot(t *testing.T) {
+	tests := []struct {
+		name      string
+		artifact  func(releaseFixture) (string, string)
+		malformed string
+		valid     string
+		validate  func(string, []byte) error
+		wantErr   string
+	}{
+		{
+			name: "Terraform Registry manifest",
+			artifact: func(fixture releaseFixture) (string, string) {
+				return "terraform-provider-openai_1.2.3_manifest.json", fixture.registry
+			},
+			malformed: `{"version":1,"metadata":{"protocol_versions":["not-a-protocol"]}}`,
+			valid:     `{"version":1,"metadata":{"protocol_versions":["6.0"]}}`,
+			validate:  verifyRegistryManifest,
+			wantErr:   "invalid protocol version",
+		},
+		{
+			name: "SPDX SBOM",
+			artifact: func(fixture releaseFixture) (string, string) {
+				return filepath.Base(fixture.archive) + ".spdx.json", fixture.archive + ".spdx.json"
+			},
+			malformed: `{"spdxVersion":"SPDX-2.3","packages":[]}`,
+			valid:     `{"spdxVersion":"SPDX-2.3","packages":[{"name":"provider"}]}`,
+			validate:  verifySPDX,
+			wantErr:   "has no version or packages",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := newReleaseFixture(t)
+			name, path := test.artifact(fixture)
+			writeFixtureFile(t, path, []byte(test.malformed))
+			fixture.writeChecksums(t)
+			manifest, err := os.ReadFile(fixture.manifest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			checksums, err := readChecksums(manifest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			replacement := filepath.Join(t.TempDir(), "structurally-valid-replacement")
+			writeFixtureFile(t, replacement, []byte(test.valid))
+
+			_, err = verifyMetadataArtifact(name, path, checksums, func(filename string, snapshot []byte) error {
+				if renameErr := os.Rename(replacement, path); renameErr != nil {
+					return renameErr
+				}
+				return test.validate(filename, snapshot)
+			})
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("structurally valid pathname replacement bypassed malformed hashed bytes: %v", err)
+			}
+		})
 	}
 }
 

--- a/.github/actions/verify-release-sboms/verify_test.go
+++ b/.github/actions/verify-release-sboms/verify_test.go
@@ -678,7 +678,7 @@ func TestProductionReleaseUsesVerifiedSigner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	publish := regexp.MustCompile(`(?ms)^  goreleaser:\n.*?^    environment: publish\n.*?^          args: release --clean --draft\n.*?^      - name: Verify and publish release draft\n`)
+	publish := regexp.MustCompile(`(?ms)^  goreleaser:\n.*?^    environment: publish\n.*?^      - name: Run GoReleaser\n.*?^          "\$RELEASE_TOOLS_DIR/goreleaser" release --clean --draft\n.*?^      - name: Verify and publish release draft\n`)
 	if !publish.Match(workflow) {
 		t.Fatal("approved production publishing job does not verify the private GoReleaser draft before publication")
 	}
@@ -706,12 +706,16 @@ func TestProductionSigningDoesNotRestoreSharedGoCache(t *testing.T) {
 		t.Fatal("production publishing job restores a shared Go build cache")
 	}
 
+	tools := strings.Index(publish, "      - name: Install authenticated release tools\n")
+	dependencies := strings.Index(publish, "      - name: Verify release dependencies\n")
 	build := strings.Index(publish, "      - name: Build trusted release verifier\n")
 	secrets := strings.Index(publish, "      - name: Check publish environment secrets\n")
 	importKey := strings.Index(publish, "      - name: Import GPG key\n")
 	release := strings.Index(publish, "      - name: Run GoReleaser\n")
-	if build < 0 || secrets < 0 || importKey < 0 || release < 0 || setupLocation[0] >= build || build >= secrets || secrets >= importKey || importKey >= release {
-		t.Fatal("trusted release verifier is not built before signing secrets are exposed")
+	if tools < 0 || dependencies < 0 || build < 0 || secrets < 0 || importKey < 0 || release < 0 ||
+		setupLocation[0] >= tools || tools >= dependencies || dependencies >= build ||
+		build >= secrets || secrets >= importKey || importKey >= release {
+		t.Fatal("trusted release tools, dependencies, and verifier are not authenticated before signing secrets are exposed")
 	}
 	trustedBuild := publish[build:secrets]
 
@@ -721,6 +725,8 @@ func TestProductionSigningDoesNotRestoreSharedGoCache(t *testing.T) {
 		`echo "GOCACHE=$GOCACHE" >> "$GITHUB_ENV"`,
 		`go build -trimpath -o "$RUNNER_TEMP/release-verifier" .github/actions/verify-release-sboms/verify.go`,
 		`echo "$RUNNER_TEMP" >> "$GITHUB_PATH"`,
+		`GONOPROXY: "none"`,
+		`GOPROXY: "off"`,
 	} {
 		if !strings.Contains(trustedBuild, command) {
 			t.Errorf("production publishing job does not enforce isolated signing prerequisite %q", command)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,22 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
-
       - name: Install authenticated release tools
         uses: ./.github/actions/setup-release-tools
 
       - name: Verify release dependencies
         uses: ./.github/actions/verify-release-dependencies
+
+      - name: Build trusted release verifier
+        run: |
+          GOCACHE="$(mktemp -d "$RUNNER_TEMP/release-go-build-cache.XXXXXX")"
+          export GOCACHE
+          echo "GOCACHE=$GOCACHE" >> "$GITHUB_ENV"
+          go build -trimpath -o "$RUNNER_TEMP/release-verifier" .github/actions/verify-release-sboms/verify.go
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+        env:
+          GONOPROXY: "none"
+          GOPROXY: "off"
 
       - name: Check publish environment secrets
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+
       - name: Install authenticated release tools
         uses: ./.github/actions/setup-release-tools
 
@@ -71,9 +72,15 @@ jobs:
       - name: Run GoReleaser
         run: |
           export PATH="$RELEASE_TOOLS_DIR:$PATH"
-          "$RELEASE_TOOLS_DIR/goreleaser" release --clean
+          "$RELEASE_TOOLS_DIR/goreleaser" release --clean --draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GONOPROXY: "none"
           GOPROXY: "off"
+
+      - name: Verify and publish release draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+        run: release-verifier --publish "$GITHUB_REF_NAME" "$GPG_FINGERPRINT"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -71,10 +71,8 @@ checksum:
   algorithm: sha256
 signs:
   - artifacts: checksum
-    cmd: go
+    cmd: release-verifier
     args:
-      - run
-      - .github/actions/verify-release-sboms/verify.go
       - "${artifact}"
       - --sign
       # if you are using this in a GitHub action or some other automated pipeline, you

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -71,7 +71,12 @@ checksum:
   algorithm: sha256
 signs:
   - artifacts: checksum
+    cmd: go
     args:
+      - run
+      - .github/actions/verify-release-sboms/verify.go
+      - "${artifact}"
+      - --sign
       # if you are using this in a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -44,7 +44,9 @@ check-terraform:
 	fi
 
 test: check-terraform
-	go test -v -cover -timeout=120s -parallel=10 ./... ./.github/actions/setup-terraform
+	go test -v -cover -timeout=120s -parallel=10 ./... \
+		./.github/actions/setup-terraform \
+		./.github/actions/verify-release-sboms
 
 testacc: check-terraform
 	TF_ACC=1 go test -v -cover -timeout $(ACC_TEST_TIMEOUT) $(ACC_TEST_PACKAGES)


### PR DESCRIPTION
## Summary

- Reuse one release-artifact verifier for CI snapshots and production checksum signing.
- Check archive/SBOM SHA-256 digests, SPDX structure, artifact pairing, and the checksum signing target while preserving the existing GPG release flow.
- Add offline regression coverage and run the verifier package in the standard test target.

## Validation

- `make test`
- `make build`
- `make lint`
- `go test -race -count=1 ./... ./.github/actions/setup-terraform ./.github/actions/verify-release-sboms`
- `go vet ./... ./.github/actions/setup-terraform ./.github/actions/verify-release-sboms`
- `actionlint` and `goreleaser check`
- Full pinned GoReleaser/Syft release snapshot across all 13 platform targets
- Local production-style GPG signing and negative artifact-integrity checks

## Rollback Plan

- [x] Revert this change or roll out an update within seven days if release behavior needs to be restored.

## Changes to Security Controls

Strengthens verification within the existing protected publish/signing flow. Workflow permissions, SHA-pinned actions, publish-environment approvals, GPG signing arguments, artifact names, and Terraform Registry compatibility remain unchanged.