### PR TITLE
fix(ci): build Go sources for CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Build Go source for CodeQL
         if: matrix.language == 'go'
         run: |
+          go clean -cache
           go build -buildvcs=false -mod=readonly ./...
           go test -buildvcs=false -mod=readonly -run '^$' ./...
           go test -buildvcs=false -mod=readonly -run '^$' ./.github/actions/setup-terraform

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,13 +27,6 @@ jobs:
     name: CodeQL (${{ matrix.language }})
     runs-on: ubuntu-latest
 
-    # These settings are ignored by the Actions extractor. Supplying an
-    # explicit dependency command keeps Go's autobuilder from invoking the
-    # repository's broad `make` target, and test files are otherwise excluded.
-    env:
-      CODEQL_EXTRACTOR_GO_BUILD_COMMAND: "go mod download"
-      CODEQL_EXTRACTOR_GO_OPTION_EXTRACT_TESTS: "true"
-
     strategy:
       fail-fast: false
       matrix:
@@ -41,7 +34,7 @@ jobs:
           - language: actions
             build-mode: none
           - language: go
-            build-mode: autobuild
+            build-mode: manual
 
     steps:
       - name: Checkout repository
@@ -62,6 +55,12 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+
+      - name: Build Go source for CodeQL
+        if: matrix.language == 'go'
+        run: |
+          go build -buildvcs=false -mod=readonly ./...
+          go test -buildvcs=false -mod=readonly -run '^$' ./...
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           go build -buildvcs=false -mod=readonly ./...
           go test -buildvcs=false -mod=readonly -run '^$' ./...
+          go test -buildvcs=false -mod=readonly -run '^$' ./.github/actions/setup-terraform
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/internal/cipolicy/codeql_workflow_test.go
+++ b/internal/cipolicy/codeql_workflow_test.go
@@ -1,0 +1,50 @@
+package cipolicy_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCodeQLBuildCoversHiddenTerraformInstaller(t *testing.T) {
+	t.Parallel()
+
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate the CodeQL workflow regression test")
+	}
+
+	workflowPath := filepath.Join(
+		filepath.Dir(sourceFile),
+		"..", "..", ".github", "workflows", "codeql.yml",
+	)
+	workflow, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("read CodeQL workflow: %v", err)
+	}
+
+	const (
+		buildStep = "- name: Build Go source for CodeQL"
+		command   = "go test -buildvcs=false -mod=readonly -run '^$' ./.github/actions/setup-terraform"
+	)
+
+	inBuildStep := false
+	for line := range strings.Lines(string(workflow)) {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "- name: ") {
+			inBuildStep = trimmed == buildStep
+			continue
+		}
+		if inBuildStep && trimmed == command {
+			return
+		}
+	}
+
+	t.Fatalf(
+		"%q must compile-test the dot-prefixed Terraform installer package with %q",
+		buildStep,
+		command,
+	)
+}

--- a/internal/cipolicy/codeql_workflow_test.go
+++ b/internal/cipolicy/codeql_workflow_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestCodeQLBuildCoversHiddenTerraformInstaller(t *testing.T) {
+func TestCodeQLBuildCoversGoSourcesFromCleanCache(t *testing.T) {
 	t.Parallel()
 
 	_, sourceFile, _, ok := runtime.Caller(0)
@@ -25,26 +25,17 @@ func TestCodeQLBuildCoversHiddenTerraformInstaller(t *testing.T) {
 		t.Fatalf("read CodeQL workflow: %v", err)
 	}
 
-	const (
-		buildStep = "- name: Build Go source for CodeQL"
-		command   = "go test -buildvcs=false -mod=readonly -run '^$' ./.github/actions/setup-terraform"
-	)
-
-	inBuildStep := false
-	for line := range strings.Lines(string(workflow)) {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "- name: ") {
-			inBuildStep = trimmed == buildStep
-			continue
-		}
-		if inBuildStep && trimmed == command {
-			return
-		}
+	const expectedBuildStep = `      - name: Build Go source for CodeQL
+        if: matrix.language == 'go'
+        run: |
+          go clean -cache
+          go build -buildvcs=false -mod=readonly ./...
+          go test -buildvcs=false -mod=readonly -run '^$' ./...
+          go test -buildvcs=false -mod=readonly -run '^$' ./.github/actions/setup-terraform`
+	if !strings.Contains(string(workflow), expectedBuildStep) {
+		t.Fatalf(
+			"CodeQL Go build must clear restored build artifacts before compiling every active source:\n%s",
+			expectedBuildStep,
+		)
 	}
-
-	t.Fatalf(
-		"%q must compile-test the dot-prefixed Terraform installer package with %q",
-		buildStep,
-		command,
-	)
 }


### PR DESCRIPTION
## Summary

- switch the Go CodeQL job from autobuild to manual build mode
- run an explicit read-only provider build so CodeQL observes real Go compilation
- compile test packages without running tests so test source remains covered
- leave the generated, build-tagged `tools/tools.go` sentinel unchanged

## Root cause

The Go autobuilder was configured with `CODEQL_EXTRACTOR_GO_BUILD_COMMAND: go mod download`. That variable is a dependency-install hook, so the workflow completed successfully without running a `go build` command. The latest analysis scanned 129 of 132 Go files and GitHub reported the tool-status error “Go files were found but not processed.”

Using CodeQL's manual build mode avoids the repository's broad Make target while providing the real build command required by the scanner.

## Impact

The CodeQL status page should return to green without changing provider behavior or generated sources. GitHub Actions analysis remains unchanged.

## Validation

- `go build -buildvcs=false -mod=readonly ./...`
- `go test -buildvcs=false -mod=readonly -run '^$' ./...`
- workflow YAML parse
- `git diff --check`
- thermo-nuclear code-quality review: no findings

A broader local `go test ./...` run passed outside two spend-limit protocol-test packages, which timed out waiting for Terraform provider reattach in the sandbox. CI is the authoritative full-suite validation.