### PR TITLE
chore: add Dependabot maturity cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 # See GitHub's documentation for more information on this file:
 # https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
 version: 2
+# Hold routine version updates for ecosystem feedback. GitHub does not apply
+# cooldowns to Dependabot security updates, which remain immediate.
 updates:
   # Maintain dependencies for Go modules
   - package-ecosystem: "gomod"
@@ -8,6 +10,8 @@ updates:
     schedule:
       # Check for updates to Go modules every weekday
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
       # Group all terraform-plugin-(go|sdk|framework|testing) dependencies together
       "terraform-plugin":
@@ -17,6 +21,8 @@ updates:
     directory: "/tools"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     groups:
@@ -28,3 +34,5 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Etc/UTC"
+    cooldown:
+      default-days: 7

--- a/internal/repopolicy/dependabot_test.go
+++ b/internal/repopolicy/dependabot_test.go
@@ -1,0 +1,93 @@
+package repopolicy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const dependabotMaturityCooldown = "\n    cooldown:\n      default-days: 7\n"
+
+func TestDependabotVersionUpdatesUseMaturityCooldown(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("..", "..", ".github", "dependabot.yml")
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read Dependabot configuration: %v", err)
+	}
+
+	updates := dependabotUpdateBlocks(string(contents))
+	wantUpdates := map[string]bool{
+		"gomod:/":          false,
+		"gomod:/tools":     false,
+		"github-actions:/": false,
+	}
+	if len(updates) != len(wantUpdates) {
+		t.Fatalf("found %d Dependabot update blocks, want %d", len(updates), len(wantUpdates))
+	}
+
+	for _, update := range updates {
+		ecosystem, err := quotedYAMLValue(update, "package-ecosystem")
+		if err != nil {
+			t.Fatal(err)
+		}
+		directory, err := quotedYAMLValue(update, "directory")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		key := ecosystem + ":" + directory
+		seen, expected := wantUpdates[key]
+		if !expected {
+			t.Fatalf("unexpected Dependabot update block %q", key)
+		}
+		if seen {
+			t.Fatalf("duplicate Dependabot update block %q", key)
+		}
+		wantUpdates[key] = true
+
+		if !strings.Contains(update, dependabotMaturityCooldown) {
+			t.Errorf("Dependabot update block %q must use a seven-day maturity cooldown", key)
+		}
+	}
+
+	for key, seen := range wantUpdates {
+		if !seen {
+			t.Errorf("missing Dependabot update block %q", key)
+		}
+	}
+}
+
+func dependabotUpdateBlocks(config string) []string {
+	const marker = "  - package-ecosystem:"
+
+	parts := strings.Split(config, marker)
+	updates := make([]string, 0, len(parts)-1)
+	for _, part := range parts[1:] {
+		updates = append(updates, marker+part)
+	}
+
+	return updates
+}
+
+func quotedYAMLValue(block, key string) (string, error) {
+	prefix := key + ":"
+	for _, line := range strings.Split(block, "\n") {
+		trimmed := strings.TrimSpace(line)
+		trimmed = strings.TrimPrefix(trimmed, "- ")
+		if !strings.HasPrefix(trimmed, prefix) {
+			continue
+		}
+
+		value := strings.TrimSpace(strings.TrimPrefix(trimmed, prefix))
+		if len(value) < 2 || value[0] != '"' || value[len(value)-1] != '"' {
+			return "", fmt.Errorf("Dependabot %s must be a quoted string, got %q", key, value)
+		}
+		return value[1 : len(value)-1], nil
+	}
+
+	return "", fmt.Errorf("Dependabot update block is missing %s", key)
+}


### PR DESCRIPTION
## Related Issue

Tracks the Dependabot configuration maturity gap in Public SDK Security.

## Description

- Add an explicit seven-day cooldown for routine version updates in the root Go module, tools Go module, and GitHub Actions.
- Keep Dependabot security updates immediate; GitHub does not apply cooldown settings to security updates.
- Add an offline repository-policy regression that requires the expected update blocks and seven-day cooldown.

GitHub option reference: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown

## Validation

- go test ./...
- go test -race -count=1 ./internal/repopolicy
- go vet ./...
- go mod verify
- tools/go mod verify
- yq semantic configuration checks
- git diff --check
- thermo-nuclear code-quality review
- security diff scan: complete coverage, zero findings

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

This adjusts supply-chain update policy for routine dependency upgrades. Routine updates receive a seven-day ecosystem maturity window, while security updates remain immediate. No access controls, credentials, permissions, encryption, or logging behavior changes.