### PR TITLE
fix: attest Terraform provider release artifacts

### DIFF
--- a/.github/actions/verify-release-sboms/provenance_test.go
+++ b/.github/actions/verify-release-sboms/provenance_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestProductionReleaseRequiresVerifiedArtifactProvenance(t *testing.T) {
+	t.Parallel()
+
+	contents, err := os.ReadFile(filepath.Join("..", "..", "..", ".github", "workflows", "release.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	workflow := string(contents)
+	publishStart := strings.Index(workflow, "\n  goreleaser:\n")
+	if publishStart < 0 {
+		t.Fatal("production publishing job was not found")
+	}
+	preflight, publish := workflow[:publishStart], workflow[publishStart:]
+
+	t.Run("protected publishing job owns attestation permissions", func(t *testing.T) {
+		if strings.Contains(preflight, "id-token: write") || strings.Contains(preflight, "attestations: write") {
+			t.Fatal("release preflight can issue OIDC tokens or create artifact attestations")
+		}
+
+		permissions := regexp.MustCompile(`(?m)^    environment: publish\n    permissions:\n      attestations: write\n      contents: write\n      id-token: write\n`)
+		if !permissions.MatchString(publish) {
+			t.Fatal("approved publishing job does not exclusively own its required release and provenance permissions")
+		}
+	})
+
+	t.Run("signed release inventory is attested before publication", func(t *testing.T) {
+		attestation := regexp.MustCompile(`(?m)^      - name: Attest verified release artifacts\n        uses: actions/attest@[0-9a-f]{40}(?:[ \t]+#[^\n]*)?\n`)
+		if !attestation.MatchString(publish) {
+			t.Fatal("release provenance action is not pinned to an immutable full commit SHA")
+		}
+
+		steps := []string{
+			"      - name: Run GoReleaser\n        id: goreleaser\n",
+			`"$RELEASE_TOOLS_DIR/goreleaser" release --clean --draft`,
+			`echo "checksums=dist/terraform-provider-openai_${GITHUB_REF_NAME#v}_SHA256SUMS" >> "$GITHUB_OUTPUT"`,
+			"      - name: Attest verified release artifacts\n",
+			"          subject-checksums: ${{ steps.goreleaser.outputs.checksums }}\n",
+			"      - name: Verify provider archive attestations\n",
+			"          for archive in dist/*.zip; do\n",
+			`gh attestation verify "$archive"`,
+			`--repo "$GITHUB_REPOSITORY"`,
+			`--signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release.yml"`,
+			`--source-ref "$GITHUB_REF"`,
+			`--source-digest "$GITHUB_SHA"`,
+			"      - name: Verify and publish release draft\n",
+		}
+
+		remaining := publish
+		for _, step := range steps {
+			index := strings.Index(remaining, step)
+			if index < 0 {
+				t.Fatalf("production release omits or misorders provenance requirement %q", step)
+			}
+			remaining = remaining[index+len(step):]
+		}
+	})
+}

--- a/.github/actions/verify-release-sboms/provenance_test.go
+++ b/.github/actions/verify-release-sboms/provenance_test.go
@@ -21,15 +21,10 @@ func TestProductionReleaseRequiresVerifiedArtifactProvenance(t *testing.T) {
 	if publishStart < 0 {
 		t.Fatal("production publishing job was not found")
 	}
-	preflight, publish := workflow[:publishStart], workflow[publishStart:]
+	publish := workflow[publishStart:]
 
 	t.Run("protected publishing job owns attestation permissions", func(t *testing.T) {
-		if strings.Contains(preflight, "id-token: write") || strings.Contains(preflight, "attestations: write") {
-			t.Fatal("release preflight can issue OIDC tokens or create artifact attestations")
-		}
-
-		permissions := regexp.MustCompile(`(?m)^    environment: publish\n    permissions:\n      attestations: write\n      contents: write\n      id-token: write\n`)
-		if !permissions.MatchString(publish) {
+		if !hasExclusiveReleaseProvenancePermissions(workflow) {
 			t.Fatal("approved publishing job does not exclusively own its required release and provenance permissions")
 		}
 	})
@@ -65,4 +60,127 @@ func TestProductionReleaseRequiresVerifiedArtifactProvenance(t *testing.T) {
 			remaining = remaining[index+len(step):]
 		}
 	})
+}
+
+func TestReleaseProvenanceRejectsUnprotectedPermissionGrants(t *testing.T) {
+	t.Parallel()
+
+	protected := "jobs:\n" +
+		"  goreleaser:\n" +
+		"    environment: publish\n" +
+		"    permissions:\n" +
+		"      attestations: write\n" +
+		"      contents: write\n" +
+		"      id-token: write\n"
+	unprotected := "  unapproved:\n" +
+		"    permissions:\n" +
+		"      attestations: write\n" +
+		"      id-token: write\n"
+
+	tests := []struct {
+		name     string
+		workflow string
+		allowed  bool
+	}{
+		{name: "only protected publishing job", workflow: protected, allowed: true},
+		{
+			name:     "workflow-wide OIDC permission",
+			workflow: "permissions:\n  id-token: write\n" + protected,
+		},
+		{
+			name:     "workflow-wide attestation permission",
+			workflow: "permissions:\n  attestations: write\n" + protected,
+		},
+		{
+			name:     "workflow-wide write-all permissions",
+			workflow: "permissions: write-all\n" + protected,
+		},
+		{
+			name:     "quoted workflow-wide write-all permissions",
+			workflow: "permissions: 'write-all' # all workflow permissions\n" + protected,
+		},
+		{
+			name:     "quoted workflow-wide write-all permission key",
+			workflow: "\"permissions\": \"write-all\"\n" + protected,
+		},
+		{
+			name:     "unapproved preceding job",
+			workflow: strings.Replace(protected, "  goreleaser:\n", unprotected+"  goreleaser:\n", 1),
+		},
+		{
+			name: "unapproved preceding write-all job",
+			workflow: strings.Replace(protected, "  goreleaser:\n",
+				"  unapproved:\n    permissions: write-all\n  goreleaser:\n", 1),
+		},
+		{
+			name:     "unapproved following job",
+			workflow: protected + unprotected,
+		},
+		{
+			name: "unapproved following job with aligned permissions",
+			workflow: protected + "  unapproved:\n" +
+				"    permissions:\n" +
+				"      id-token:    write\n" +
+				"      attestations:    write\n",
+		},
+		{
+			name: "unapproved following job with quoted permissions",
+			workflow: protected + "  unapproved:\n" +
+				"    permissions:\n" +
+				"      'id-token': \"write\"\n" +
+				"      \"attestations\": 'write'\n",
+		},
+		{
+			name: "unapproved following job with inline permissions",
+			workflow: protected + "  unapproved:\n" +
+				"    permissions: {id-token: write, attestations: write}\n",
+		},
+		{
+			name:     "unapproved following write-all job",
+			workflow: protected + "  unapproved:\n    permissions: write-all\n",
+		},
+		{
+			name: "unapproved following write-all job with quoted permission key",
+			workflow: protected + "  unapproved:\n" +
+				"    'permissions': 'write-all'\n",
+		},
+		{
+			name:     "unprotected publishing environment",
+			workflow: strings.Replace(protected, "environment: publish", "environment: staging", 1),
+		},
+		{
+			name:     "missing OIDC permission",
+			workflow: strings.Replace(protected, "id-token: write", "id-token: read", 1),
+		},
+		{
+			name:     "missing attestation permission",
+			workflow: strings.Replace(protected, "attestations: write", "attestations: read", 1),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if allowed := hasExclusiveReleaseProvenancePermissions(test.workflow); allowed != test.allowed {
+				t.Fatalf("release provenance permissions allowed = %t, want %t", allowed, test.allowed)
+			}
+		})
+	}
+}
+
+func hasExclusiveReleaseProvenancePermissions(workflow string) bool {
+	writeAll := regexp.MustCompile(`(?m)^[ \t]*["']?permissions["']?[ \t]*:[ \t]*["']?write-all["']?[ \t]*(?:#.*)?$`)
+	if writeAll.MatchString(workflow) {
+		return false
+	}
+
+	for _, permission := range []string{"id-token", "attestations"} {
+		grant := regexp.MustCompile(`(?m)(?:^|[,{])[ \t]*["']?` + regexp.QuoteMeta(permission) +
+			`["']?[ \t]*:[ \t]*["']?write["']?[ \t]*(?:[,}]|#.*|$)`)
+		if len(grant.FindAllStringIndex(workflow, -1)) != 1 {
+			return false
+		}
+	}
+
+	protected := regexp.MustCompile(`(?m)^    environment: publish\n    permissions:\n      attestations: write\n      contents: write\n      id-token: write\n`)
+	return protected.MatchString(workflow)
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ jobs:
     needs: release-sbom
     runs-on: ubuntu-latest
     environment: publish
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -70,14 +74,33 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
 
       - name: Run GoReleaser
+        id: goreleaser
         run: |
           export PATH="$RELEASE_TOOLS_DIR:$PATH"
           "$RELEASE_TOOLS_DIR/goreleaser" release --clean --draft
+          echo "checksums=dist/terraform-provider-openai_${GITHUB_REF_NAME#v}_SHA256SUMS" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GONOPROXY: "none"
           GOPROXY: "off"
+
+      - name: Attest verified release artifacts
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-checksums: ${{ steps.goreleaser.outputs.checksums }}
+
+      - name: Verify provider archive attestations
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for archive in dist/*.zip; do
+            gh attestation verify "$archive" \
+              --repo "$GITHUB_REPOSITORY" \
+              --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release.yml" \
+              --source-ref "$GITHUB_REF" \
+              --source-digest "$GITHUB_SHA"
+          done
 
       - name: Verify and publish release draft
         env:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -47,7 +47,7 @@ To publish a provider version:
    git push origin v0.1.0
    ```
 
-The `Release` workflow waits for the `publish` environment checks, imports the GPG key from environment secrets, and runs GoReleaser. GoReleaser builds OS/architecture zip files, generates an SPDX JSON software bill of materials (SBOM) for each zip, includes the SBOMs in the signed checksum file, includes `terraform-registry-manifest.json`, and creates the GitHub Release.
+The `Release` workflow waits for the `publish` environment checks, imports the GPG key from environment secrets, and runs GoReleaser. GoReleaser builds OS/architecture zip files, generates an SPDX JSON software bill of materials (SBOM) for each zip, includes the SBOMs in the signed checksum file, includes `terraform-registry-manifest.json`, and creates a draft GitHub Release. The approved publishing job then generates GitHub OIDC-backed build-provenance attestations for every artifact in the verified, signed checksum file, including each provider archive, SBOM, and registry manifest. It verifies every provider archive's attestation against this repository, release workflow, version tag, and source commit before publishing the draft. A missing, invalid, or mismatched attestation blocks publication.
 
 CI builds a snapshot release and verifies that every provider zip has a non-empty SBOM listed in the checksum file. The tag-triggered `Release` workflow runs the same `Release SBOM` verification before its publish job, so a release cannot be published if that check fails. Both the snapshot and publish jobs first verify their own checked-out provider dependencies before building artifacts.
 
@@ -55,7 +55,7 @@ Once the public Terraform Registry is connected to the public repository, finali
 
 ## Release Security
 
-The `publish` environment approval is the security boundary for release signing. Before approving a release job, reviewers should verify that the tag points at the intended reviewed commit and that the release workflow and `.goreleaser.yml` at that commit are expected.
+The `publish` environment approval is the security boundary for release signing and OIDC-backed provenance. Before approving a release job, reviewers should verify that the tag points at the intended reviewed commit and that the release workflow and `.goreleaser.yml` at that commit are expected. Only this approved job receives `id-token: write` and `attestations: write`; the preceding snapshot-verification job remains read-only. Terraform Registry still requires GPG-signed provider checksums, so the GitHub attestation supplements rather than replaces the GPG signature.
 
 Each release job first installs pinned GoReleaser and Syft release archives and authenticates each archive against a SHA-256 digest committed in `.github/actions/setup-release-tools/install.sh`. Tool installation fails closed if an archive cannot be downloaded, does not match its reviewed digest, or does not contain the expected executable; no mutable upstream installers or unauthenticated tool caches are used.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,3 +30,24 @@ Please coordinate respectfully with OpenAI's security team.
 
 Please follow OpenAI's coordinated vulnerability disclosure policy:
 https://openai.com/policies/coordinated-vulnerability-disclosure-policy
+
+## Verifying release provenance
+
+Terraform verifies the GPG-signed provider checksum when installing from the
+Terraform Registry. Provider release archives also carry GitHub artifact
+attestations linking their SHA-256 digests to this repository's protected
+release workflow and the corresponding version tag.
+
+After downloading a provider archive, verify its build provenance with the
+GitHub CLI:
+
+```sh
+version=1.2.3
+gh attestation verify "terraform-provider-openai_${version}_linux_amd64.zip" \
+  --repo openai/terraform-provider-openai \
+  --signer-workflow openai/terraform-provider-openai/.github/workflows/release.yml \
+  --source-ref "refs/tags/v${version}"
+```
+
+Set `version` to the downloaded provider version and choose the archive for the
+appropriate operating system and architecture.


### PR DESCRIPTION
## Summary

- Generate GitHub OIDC-backed build-provenance attestations for every provider archive, SPDX SBOM, and registry manifest in the already verified, GPG-signed release checksum inventory.
- Confine OIDC and attestation-write permissions to the reviewer-protected `publish` job and fail closed unless every provider archive verifies against the exact repository, release workflow, version tag, and source commit before the draft release is published.
- Preserve Terraform Registry's required GPG signatures, document downstream verification, and add regression coverage for least privilege, immutable action pinning, complete subjects, and publication ordering.

## Verification

- `make test`
- `go test -race -count=1 ./.github/actions/verify-release-sboms`
- `go test -cover -timeout=120s -parallel=10 ./... ./.github/actions/setup-terraform ./.github/actions/verify-release-sboms`
- `go vet ./... ./.github/actions/setup-terraform ./.github/actions/verify-release-sboms`
- `make build`
- `go mod verify` in the root and `tools` modules
- `make generate` and verified no generated documentation or lockfile changes
- `terraform fmt -check -recursive examples`
- `bash .github/actions/setup-release-tools/install_test.sh`
- Focused security diff review: all four changed files reviewed; no findings.

The first production release after merge should confirm live OIDC attestation generation, downstream archive verification, and normal Terraform Registry ingestion.
